### PR TITLE
mapper 완료

### DIFF
--- a/ecovery/src/main/java/com/ecovery/domain/FreeReplyVO.java
+++ b/ecovery/src/main/java/com/ecovery/domain/FreeReplyVO.java
@@ -23,5 +23,6 @@ public class FreeReplyVO {
     private Long freeId; // 게시글 ID (FK)
     private Long memberId; // 댓글 작성자 ID (FK)
     private String content; // 댓글 본문 내용
+    private Long parentId; // 부모 댓글 ID (NULL이면 일반댓글)
     private LocalDateTime createdAt; // 댓글 작성일시
 }

--- a/ecovery/src/main/java/com/ecovery/domain/FreeVO.java
+++ b/ecovery/src/main/java/com/ecovery/domain/FreeVO.java
@@ -31,10 +31,12 @@ public class FreeVO {
     private String category;    // 품목 카테고리
     private String regionGu;    // 나눔지역 - 구
     private String regionDong;  // 나눔지역 - 동
-    private Integer viewCount; // 게시글 조회수
+    private int viewCount; // 게시글 조회수
     private LocalDateTime createdAt; // 게시글 등록/수정일(시간포함)
 
     // enum 타입
     private ItemCondition itemCondition; // 삼품 상태(HIGH/MEDIUM/LOW)
     private DealStatus dealStatus; // 거래 상태(ONGOING, DONE)
+
+    private String nickname;
 }

--- a/ecovery/src/main/java/com/ecovery/dto/Criteria.java
+++ b/ecovery/src/main/java/com/ecovery/dto/Criteria.java
@@ -37,6 +37,10 @@ public class Criteria {
         return type == null? new String[] {}: type.split("");
     }
 
+    //MySQL OFFSET 계산용 메소드
+    public int getOffset(){
+        return (pageNum - 1) * amount;
+    }
 
 
 }

--- a/ecovery/src/main/java/com/ecovery/dto/FreeDto.java
+++ b/ecovery/src/main/java/com/ecovery/dto/FreeDto.java
@@ -20,7 +20,8 @@ public class FreeDto {
     private String category;
     private DealStatus dealStatus;
     private String title;
-    private String nickName;
+    private String nickname;
     private String createdAt;
-    private Integer viewCount;
+    private int viewCount;
+
 }

--- a/ecovery/src/main/java/com/ecovery/dto/FreeReplyDto.java
+++ b/ecovery/src/main/java/com/ecovery/dto/FreeReplyDto.java
@@ -8,6 +8,7 @@ import java.util.List;
 /*
  * 무료나눔 댓글 DTO
  * 댓글 내용을 화면에 전달하기 위한 데이터 전달 객체
+ * 부모-자식 구조로 대댓글 계층 표현 가능
  * @author : yeonsu
  * @fileName : FreeReplyDto
  * @since : 250711

--- a/ecovery/src/main/java/com/ecovery/mapper/FreeImgMapper.java
+++ b/ecovery/src/main/java/com/ecovery/mapper/FreeImgMapper.java
@@ -17,7 +17,7 @@ import java.util.List;
 @Mapper
 public interface FreeImgMapper {
 
-    public void insert(FreeImgVO freeImgVO);             // 이미지 1장 등록
+    public void insert(FreeImgVO freeImgVO);             // 이미지 등록
 
     public int update(FreeImgVO freeImgVO);              // 이미지 수정시 이미지 교체
 

--- a/ecovery/src/main/java/com/ecovery/mapper/FreeMapper.java
+++ b/ecovery/src/main/java/com/ecovery/mapper/FreeMapper.java
@@ -30,7 +30,7 @@ public interface FreeMapper {
 
     public int delete(Long freeId);                       // 게시글 삭제 (성공시 1, 실패시 0)
 
-    public List<FreeDto> getListWithPaging(Criteria cri); // 게시글 목록 조회 (작성자 닉네임 포함)
+    public List<FreeVO> getListWithPaging(Criteria cri); // 게시글 목록 조회 (작성자 닉네임 포함)
 
     public int getTotalCount(Criteria cri);               //페이징 처리를 위한 전체 게시글 수 조회
 

--- a/ecovery/src/main/resources/mapper/FreeImgMapper.xml
+++ b/ecovery/src/main/resources/mapper/FreeImgMapper.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.ecovery.mapper.FreeImgMapper">
+
+<!--
+ * 무료나눔 이미지 Mapper XML
+ * 게시글과 연결된 이미지 관련 SQL문을 정의한 MyBatis 매퍼 파일
+ *
+ * @author : yeonsu
+ * @fileName : FreeImgMapper.xml
+ * @since : 250714
+-->
+
+    <!-- 이미지 등록 -->
+    <insert id="insert" parameterType="com.ecovery.domain.FreeImgVO">
+        INSERT INTO free_img (
+                              free_id, img_name,
+                              ori_img_name, img_url, rep_img_yn
+        )
+        VALUES (#{freeId}, #{imgName}, #{oriImgName}, #{imgUrl}, #{repImgYn})
+    </insert>
+
+    <!-- 이미지 수정시 이미지 교체 -->
+    <update id="update" parameterType="com.ecovery.domain.FreeImgVO">
+        UPDATE free_img
+        SET img_name = #{imgName},
+            ori_img_name = #{oriImgName},
+            img_url = #{imgUrl},
+            rep_img_yn = #{repImgYn}
+        WHERE free_img_id = #{freeImgId}
+    </update>
+
+    <!-- 게시글에 연결된 전체 이미지 조회 -->
+    <select id="getFreeImgList" resultType="com.ecovery.dto.FreeImgDto">
+        SELECT free_img_id, free_id, img_name, ori_img_name, img_url, rep_img_yn
+        FROM free_img
+        WHERE free_id = #{freeId}
+        ORDER BY free_img_id
+    </select>
+
+    <!-- UUID 기준으로 이미지 1건 삭제 -->
+    <delete id="deleteByUuid" parameterType="string">
+        DELETE FROM free_img
+        WHERE img_name = #{uuid}
+    </delete>
+
+    <!-- 게시글에 연결된 이미지 전체 삭제 -->
+    <delete id="deleteByFreeId" parameterType="LONG">
+        DELETE FROM free_img
+        WHERE free_id = #{freeId}
+    </delete>
+
+    <!-- 대표 이미지 1장 조회 -->
+    <select id="getRepImg" resultType="com.ecovery.dto.FreeImgDto">
+        SELECT free_img_id, free_id, img_name, ori_img_name, img_url, rep_img_yn
+        FROM free_img
+        WHERE free_id = #{freeId}
+          AND rep_img_yn = 'Y'
+        LIMIT 1
+    </select>
+</mapper>

--- a/ecovery/src/main/resources/mapper/FreeMapper.xml
+++ b/ecovery/src/main/resources/mapper/FreeMapper.xml
@@ -2,31 +2,161 @@
 <!DOCTYPE mapper
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-
 <mapper namespace="com.ecovery.mapper.FreeMapper">
 
-    <!-- FreeVO 매핑-->
-    <resultMap id="freeMap" type="com.ecovery.domain.FreeVO">
-        <id property="freeId" column="free_id"/>
-        <result property="memberId" column="member_id"/>
-        <result property="title" column="title"/>
-        <result property="content" column="content"/>
-        <result property="category" column="category"/>
-        <result property="regionGu" column="region_gu"/>
-        <result property="regionDong" column="region_dong"/>
-        <result property="viewCount" column="view_count"/>
-        <result property="createdAt" column="created_at"/>
-        <result property="itemCondition" column="item_condition"/>
-        <result property="dealStatus" column="deal_status"/>
-    </resultMap>
+
+<!--
+ * 무료나눔 게시판 Mapper XML
+ * 게시글 관련 SQL문을 정의한 MyBatis 매퍼 파일
+ * - 게시글 등록, 조회, 수정, 삭제 기능 포함
+ * - 작성자 닉네임, 대표 이미지 등을 조인하여 함께 조회 가능
+ * - 페이징 및 검색 기능 쿼리도 포함되어 있음
+ *
+ * @author : yeonsu
+ * @fileName : FreeMapper.xml
+ * @since : 250714
+-->
+
+
+    <!-- 게시글 단건 조회 -->
+    <select id="read" resultType="com.ecovery.domain.FreeVO">
+        SELECT
+            f.free_id,
+            f.title,
+            f.content,
+            f.region_gu,
+            f.region_dong,
+            f.view_count,
+            f.created_at,
+            f.item_condition,
+            f.deal_status,
+            m.nickname
+        FROM free f
+                 JOIN member m ON f.member_id = m.member_id
+        WHERE f.free_id = #{freeId}
+    </select>
 
 
     <!-- 게시글 전체 목록 조회 -->
     <select id="getFreeList" resultType="com.ecovery.dto.FreeDto">
-        select f.*, m.nick_name
-        from free f
-        join member m on f.member_id = m.member_id
-        order by f.free_id DESC
+        SELECT
+            f.free_id,
+            f.title,
+            f.category,
+            f.region_gu,
+            f.view_count,
+            f.item_condition,
+            i.img_url,
+            i.repimg_yn
+        FROM free f
+        JOIN free_img i ON f.free_id = i.free_id AND i.repimg_yn = 'Y'
+        ORDER BY f.free_id DESC
     </select>
 
+    <!-- 게시글 삽입-->
+    <insert id="insert">
+        INSERT INTO free(
+                         title, member_id, category, region_gu,
+                         region_dong, content, item_condition
+        )
+        VALUES (
+                #{title}, #{memberId}, #{category}, #{regionGu},
+                #{regionDong}, #{content}, #{itemCondition}
+               )
+    </insert>
+
+    <!-- 게시글 삽입하면서 생성된 PK도 함께 가져오기-->
+    <insert id="insertSelectKey" useGeneratedKeys="true" keyProperty="freeId">
+        INSERT INTO free (title, member_id, category, region_gu, region_dong, content, item_condition)
+        VALUES (#{title}, #{memberId}, #{category}, #{regionGu}, #{regionDong}, #{content}, #{itemCondition})
+    </insert>
+
+    <!-- update -->
+    <update id="update" parameterType="com.ecovery.domain.FreeVO">
+        UPDATE free
+        SET title = #{title}, category = #{category}, region_gu = #{regionGu}, region_dong = #{regionDong},
+            content = #{content}, item_condition = #{itemCondition}, deal_status = #{dealStatus}
+        WHERE free_id = #{freeId}
+    </update>
+
+    <!-- 게시글 삭제-->
+    <delete id="delete" parameterType="Long">
+        DELETE FROM free WHERE free_id = #{freeId}
+    </delete>
+
+    <!-- 페이징 처리 게시글 목록 쿼리(MYSQL) -->
+    <select id="getListWithPaging" resultType="com.ecovery.domain.FreeVO">
+        SELECT
+            free_id,
+            member_id,
+            title,
+            content,
+            category,
+            region_gu,
+            region_dong,
+            view_count,
+            created_at,
+            item_condition,
+            deal_status
+        FROM free
+        <include refid="criteria"/>
+        ORDER BY free_id DESC
+        LIMIT #{amount} OFFSET #{offset}
+    </select>
+
+    <!-- 검색 조건(제목, 내용, 지역(구,동) -->
+    <sql id="criteria">
+        <where>
+            <foreach collection="typeArr" item="type" separator="OR">
+                <if test="type == 'T'">
+                    title LIKE CONCAT('%', #{keyword}, '%')
+                </if>
+                <if test="type == 'C'">
+                    content LIKE CONCAT('%', #{keyword}, '%')
+                </if>
+                <if test="type == 'R'">
+                    region_gu LIKE CONCAT('%', #{keyword}, '%')
+                    OR region_dong LIKE CONCAT('%', #{keyword}, '%')
+                </if>
+            </foreach>
+        </where>
+    </sql>
+
+    <!-- 페이징 처리를 위한 전체 게시글 수를 조회 -->
+    <select id="getTotalCount" parameterType="com.ecovery.dto.Criteria" resultType="int">
+        SELECT COUNT(*) FROM free
+        <where>
+            <if test="type != null and keyword != null and keywork != ''">
+                <include refid="criteria"></include>
+            </if>
+            free_id > 0 <!-- 항상 참인 기본 조건  : WHRER 문이 비어있을 때 대비용-->
+        </where>
+    </select>
+
+    <!-- 조회수를 1 증가-->
+    <update id="updateViewCount" parameterType="int">
+        UPDATE free
+        SET view_count = view_count + 1
+        WHERE free_id = #{freeId}
+    </update>
+
+    <!-- 게시글 상세 조회 + 작성자 닉네임 포함 -->
+    <select id="readWithWriter" parameterType="long" resultType="com.ecovery.dto.FreeDto">
+        SELECT
+            f.free_id,
+            f.member_id,
+            f.title,
+            f.content,
+            f.category,
+            f.region_gu,
+            f.region_dong,
+            f.view_count,
+            f.created_at,
+            f.item_condition,
+            f.deal_status,
+            m.nickname
+        FROM free f
+        JOIN member m ON f.member_id = m.member_id
+        WHERE f.free_id = #{freeId}
+    </select>
 </mapper>

--- a/ecovery/src/main/resources/mapper/FreeReplyMapper.xml
+++ b/ecovery/src/main/resources/mapper/FreeReplyMapper.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.ecovery.mapper.FreeReplyMapper">
+
+<!--
+* 무료나눔 댓글 Mapper XML
+* 댓글 및 대댓글 관련 SQL문을 정의한 MyBatis 매퍼 파일
+*
+* @author : yeonsu
+* @fileName : FreeReplyMapper.xml
+* @since : 250714
+-->
+
+    <!-- 댓글 등록 -->
+    <insert id="insert" parameterType="com.ecovery.domain.FreeReplyVO">
+        INSERT INTO free_reply (
+                                free_id, member_id,
+                                content, parent_id, created_at
+        )
+        VALUES (
+                #{freeId}, #{memberId},
+                #{content}, #{parentId}, NOW()
+        )
+    </insert>
+
+    <!-- 댓글 조회 -->
+    <select id="read" resultType="com.ecovery.dto.FreeReplyDto">
+        SELECT r.reply_id,
+               r.free_id,
+               r.member_id,
+               r.content,
+               r.parent_id,
+               r.created_at,
+               m.nick_name
+        FROM free_reply r
+        JOIN member m ON r.member_id = m.member_id
+        WHERE r.reply_id = #{replyId}
+    </select>
+
+    <!-- 댓글 수정 -->
+    <update id="update" parameterType="com.ecovery.domain.FreeReplyVO">
+        UPDATE free_reply
+        SET content = #{content}
+        WHERE reply_id = #{replyId}
+    </update>
+
+    <!-- 댓글 삭제 -->
+    <delete id="delete" parameterType="Long">
+        DELETE FROM free_reply
+        WHERE reply_id = #{replyId}
+    </delete>
+
+    <!-- 게시글의 부모 댓글 목록 조회 (parent_id IS NULL) -->
+    <select id="getParentReplies" resultType="com.ecovery.dto.FreeReplyDto">
+        SELECT
+            r.reply_id, r.free_id, r.member_id,
+            r.content, r.parent_id, r.created_at,
+            m.nick_name
+        FROM free_reply r
+        JOIN member m ON r.member_id = m.member_id
+        WHERE r.free_id = #{freeId}
+        AND r.parent_id IS NULL
+        <choose>
+            <when test="sortType == 'recent'">
+                ORDER BY r.created_at DESC
+            </when>
+            <otherwise>
+                ORDER BY r.created_at ASC
+            </otherwise>
+        </choose>
+    </select>
+
+    <!-- 게시글의 전체 댓글 수 (부모 + 대댓글 포함) -->
+    <select id="getTotalReplyCount" resultType="int">
+        SELECT COUNT(*)
+        FROM free_reply
+        WHERE free_id = #{freeId}
+    </select>
+
+
+
+
+
+
+
+</mapper>

--- a/ecovery/src/test/java/com/ecovery/mapper/FreeMapperTest.java
+++ b/ecovery/src/test/java/com/ecovery/mapper/FreeMapperTest.java
@@ -1,0 +1,55 @@
+package com.ecovery.mapper;
+
+import com.ecovery.constant.ItemCondition;
+import com.ecovery.domain.FreeVO;
+import jdk.dynalink.linker.support.Guards;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Slf4j
+class FreeMapperTest {
+
+    @Autowired
+    private FreeMapper freeMapper;
+
+    @Test
+    @DisplayName("게시글 등록 테스트")
+    @Transactional
+    public void testInsert() {
+
+        // Given (준비)
+        FreeVO vo = new FreeVO();
+        vo.setTitle("테스트 제목");
+        vo.setMemberId(1L);
+        vo.setCategory("가구");
+        vo.setRegionGu("강남구");
+        vo.setRegionDong("역삼동");
+        vo.setContent("테스트 내용");
+        vo.setItemCondition(ItemCondition.HIGH);
+
+        // When (실행)
+        freeMapper.insertSelectKey(vo);
+
+        // Then (검증)
+        // 1) insert 후 FreeId가 자동으로 채워졌는지
+        assertNotNull(vo.getFreeId(), "id는 null값이면 안됩니다.");
+
+        // 2) 방금 insert한 데이터 조회 (PK로 단건 조회)
+        FreeVO inserted = freeMapper.read(vo.getFreeId());
+        assertNotNull(inserted, "insert 이후에는 null값이면 안됩니다.");
+
+        // 3) DB에 저장된 데이터가 내가 입력한 값이랑 같은지 검증 (예상괎과 실제값 비교)
+        assertEquals("테스트 제목", inserted.getTitle());
+        assertEquals("테스트 내용", inserted.getContent());
+
+        log.info("삽입된 게시글 : {}", inserted);
+    }
+
+}

--- a/ecovery/src/test/java/com/ecovery/mapper/FreeReplyMapperTest.java
+++ b/ecovery/src/test/java/com/ecovery/mapper/FreeReplyMapperTest.java
@@ -1,0 +1,32 @@
+//package com.ecovery.mapper;
+//
+//import com.ecovery.domain.FreeReplyVO;
+//import lombok.extern.slf4j.Slf4j;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//
+//import static org.junit.jupiter.api.Assertions.*;
+//
+//@SpringBootTest
+//@Slf4j
+//class FreeReplyMapperTest {
+//
+//    @Autowired
+//    private FreeReplyMapper freeReplyMapper;
+//
+//    @Test
+//    public void testInsertReply() {
+//        FreeReplyVO vo = new FreeReplyVO();
+//        vo.setFreeId(1L);               // 게시글 ID
+//        vo.setMemberId(2L);             // 작성자 ID
+//        vo.setContent("댓글 테스트");
+//        vo.setParentId(null);           // 일반 댓글 (null) 또는 대댓글일 경우 부모 ID
+//        // createdAt은 DB에서 NOW()로 자동 처리
+//
+//        freeReplyMapper.insert(vo);     // Mapper 호출
+//
+//        log.info("삽입된 댓글 ID = {}", vo.getReplyId()); // @Options가 설정된 경우에만 값 확인 가능
+//    }
+//}
+//


### PR DESCRIPTION
2025-07-14 (월)
1. FreeMapper.xml 작성
- 무료나눔 게시판 수정화면에서 작성자 칸 수정 못하게 (등록화면이랑 똑같이 구현)
- 무료나눔 게시판 메인페이지 검색조건(제목, 내용, 지역) 지역은 ㅇㅇ구, ㅇㅇ동 둘 다 검색 가능하게 구현 

2. FreeImgMapper.xml,  FreeReplyMapper.xml 
- 문제 없이 작성됨, test는 아직 
- FreeReplyMapperTest는 테스트 코드만 작성하고 실행 안시킴 (순서가 안됨)

3. free_reply 무료나눔 게시글 댓글 테이블 내용 추가
parent_id BIGINT DEFAULT NULL => 이렇게 추가하여 부모 댓글 ID 컬럼을 생성
FOREIGN KEY (parent_id) REFERENCES free_reply(reply_id) => parent_id 값은 반드시 free_reply 테이블에 있는 reply_id중 하나여야 해서 외래키로 생성
Null이면 일반 댓글, 값 있으면 대댓글 => 대댓글의 parent_id 값은 해당 대댓글이 달린 부모 댓글의 reply_id 값 
				ex) 대댓글이 1번 댓글에 달리면 -> parent_id = 1 이런식으로 

4. FreeMapperTest 작성
- when, then, given형식으로 게시글 등록 테스트 완료 