### PR TITLE
20250716

### DIFF
--- a/ecovery/src/main/java/com/ecovery/domain/FreeReplyVO.java
+++ b/ecovery/src/main/java/com/ecovery/domain/FreeReplyVO.java
@@ -1,8 +1,6 @@
 package com.ecovery.domain;
 
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -17,6 +15,9 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @ToString
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class FreeReplyVO {
 
     private Long replyId; // 댓글 고유번호(PK)

--- a/ecovery/src/main/java/com/ecovery/dto/FreeDto.java
+++ b/ecovery/src/main/java/com/ecovery/dto/FreeDto.java
@@ -3,6 +3,7 @@ package com.ecovery.dto;
 import com.ecovery.constant.DealStatus;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 /*
  * 무료나눔 게시글 DTO
@@ -14,6 +15,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
+@ToString
 public class FreeDto {
     private Long freeId;
     private String regionGu;

--- a/ecovery/src/main/java/com/ecovery/dto/FreeImgDto.java
+++ b/ecovery/src/main/java/com/ecovery/dto/FreeImgDto.java
@@ -2,6 +2,7 @@ package com.ecovery.dto;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 /*
  * 무료나눔 이미지 DTO
@@ -13,6 +14,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
+@ToString
 public class FreeImgDto {
 
     private Long freeImgId;

--- a/ecovery/src/main/java/com/ecovery/dto/FreeReplyDto.java
+++ b/ecovery/src/main/java/com/ecovery/dto/FreeReplyDto.java
@@ -2,6 +2,7 @@ package com.ecovery.dto;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -16,6 +17,7 @@ import java.util.List;
 
 @Getter
 @Setter
+@ToString
 public class FreeReplyDto {
 
     private Long replyId;    // 댓글 번호

--- a/ecovery/src/main/java/com/ecovery/mapper/FreeImgMapper.java
+++ b/ecovery/src/main/java/com/ecovery/mapper/FreeImgMapper.java
@@ -23,12 +23,9 @@ public interface FreeImgMapper {
 
     public List<FreeImgDto> getFreeImgList(Long freeId); // 게시글에 연결된 전체 이미지 조회
 
-    public int delete(Long freeImgId);                   // UUID 기준으로 이미지 1건 삭제(성공시 1, 실패시 0)
+    public int delete(Long freeImgId);                   // 이미지 고유번호 기준으로 이미지 1건 삭제(성공시 1, 실패시 0)
 
-    public int deleteByFreeId(Long freeId);              // 게시글에 연결된 이미지 전체 삭제(성공시 1, 실패시 0)
-                                                         // (ex.게시글 삭제시, 이미지 5장 삭제시 return = 5)
-
-    public FreeImgDto getRepImg(Long freeId);            //
+    public FreeImgDto getRepImg(Long freeId);            // 게시글에 등록된 대표이미지 한장 가져오기
 
 
 

--- a/ecovery/src/main/java/com/ecovery/mapper/FreeMapper.java
+++ b/ecovery/src/main/java/com/ecovery/mapper/FreeMapper.java
@@ -24,8 +24,6 @@ public interface FreeMapper {
 
     public void insert(FreeVO freeVO);                    // 게시글 등록
 
-    public void insertSelectKey(FreeVO freeVO);           // 게시글 등록 후 생성된 PK를 freeVO에 저장
-
     public int update(FreeVO freeVO);                     // 게시글 수정 (성공시 1, 실패시 0)
 
     public int delete(Long freeId);                       // 게시글 삭제 (성공시 1, 실패시 0)

--- a/ecovery/src/main/java/com/ecovery/mapper/FreeReplyMapper.java
+++ b/ecovery/src/main/java/com/ecovery/mapper/FreeReplyMapper.java
@@ -20,12 +20,12 @@ public interface FreeReplyMapper {
 
     public void insert(FreeReplyVO freeReply);             // 댓글 등록
 
-    public FreeReplyDto read(Long replyId);                // 댓글 조회
+    public FreeReplyDto read(Long replyId);                // 댓글 조회(특정댓글 1개)
 
     public int update(FreeReplyVO freeReply);              // 댓글 수정
 
     public int delete(Long replyId);                       // 댓글 삭제
-
+    
     public List<FreeReplyDto> getParentReplies(@Param("freeId") Long freeId,     // 게시글의 부모 댓글 목록 조회(정렬 기준: 최신순/등록순)
                                                @Param("sortType") String sortType);
 
@@ -33,5 +33,6 @@ public interface FreeReplyMapper {
 
     public int getTotalReplyCount(Long freeId);            // 해당 게시글의 전체 댓글 수 (페이징)
 
+    public int getChildReplyCount(Long parentId);           //특정 부모 댓글의 대댓글 수 조회
 
 }

--- a/ecovery/src/main/java/com/ecovery/service/FreeService.java
+++ b/ecovery/src/main/java/com/ecovery/service/FreeService.java
@@ -1,0 +1,4 @@
+package com.ecovery.service;
+
+public interface FreeService {
+}

--- a/ecovery/src/main/resources/application.yml
+++ b/ecovery/src/main/resources/application.yml
@@ -34,10 +34,10 @@ spring:
       max-request-size: 100MB # 요청당 최대 파일 크기
 
 # 상품 이미지 업로드 경로
-#itemImgLocation: C:/ecovery/item
+itemImgLocation: C:/ecovery/item
 
 # 리소스 이미지 업로드 경로
-#uploadPath: file:///C:/ecovery/
+uploadPath: file:///C:/ecovery/
 
 
 mybatis:

--- a/ecovery/src/main/resources/mapper/FreeImgMapper.xml
+++ b/ecovery/src/main/resources/mapper/FreeImgMapper.xml
@@ -14,7 +14,7 @@
 -->
 
     <!-- 이미지 등록 -->
-    <insert id="insert" parameterType="com.ecovery.domain.FreeImgVO">
+    <insert id="insert" parameterType="com.ecovery.domain.FreeImgVO" useGeneratedKeys="true" keyProperty="freeImgId">
         INSERT INTO free_img (
                               free_id, img_name,
                               ori_img_name, img_url, repimg_yn

--- a/ecovery/src/main/resources/mapper/FreeMapper.xml
+++ b/ecovery/src/main/resources/mapper/FreeMapper.xml
@@ -75,7 +75,7 @@
     </select>
 
     <!-- 게시글 삽입-->
-    <insert id="insert">
+    <insert id="insert" parameterType="com.ecovery.domain.FreeVO" useGeneratedKeys="true" keyProperty="freeId">
         INSERT INTO free(
                          title, member_id, category, region_gu,
                          region_dong, content, item_condition
@@ -84,12 +84,6 @@
                 #{title}, #{memberId}, #{category}, #{regionGu},
                 #{regionDong}, #{content}, #{itemCondition}
                )
-    </insert>
-
-    <!-- 게시글 삽입하면서 생성된 PK도 함께 가져오기-->
-    <insert id="insertSelectKey" useGeneratedKeys="true" keyProperty="freeId">
-        INSERT INTO free (title, member_id, category, region_gu, region_dong, content, item_condition)
-        VALUES (#{title}, #{memberId}, #{category}, #{regionGu}, #{regionDong}, #{content}, #{itemCondition})
     </insert>
 
     <!-- update -->

--- a/ecovery/src/main/resources/mapper/FreeReplyMapper.xml
+++ b/ecovery/src/main/resources/mapper/FreeReplyMapper.xml
@@ -14,7 +14,7 @@
 -->
 
     <!-- 댓글 등록 -->
-    <insert id="insert" parameterType="com.ecovery.domain.FreeReplyVO">
+    <insert id="insert" parameterType="com.ecovery.domain.FreeReplyVO" useGeneratedKeys="true" keyProperty="replyId">
         INSERT INTO free_reply (
                                 free_id, member_id,
                                 content, parent_id, created_at
@@ -33,7 +33,7 @@
                r.content,
                r.parent_id,
                r.created_at,
-               m.nick_name
+               m.nickname
         FROM free_reply r
         JOIN member m ON r.member_id = m.member_id
         WHERE r.reply_id = #{replyId}
@@ -46,18 +46,20 @@
         WHERE reply_id = #{replyId}
     </update>
 
+
     <!-- 댓글 삭제 -->
     <delete id="delete" parameterType="Long">
         DELETE FROM free_reply
         WHERE reply_id = #{replyId}
     </delete>
 
+
     <!-- 게시글의 부모 댓글 목록 조회 (parent_id IS NULL) -->
     <select id="getParentReplies" resultType="com.ecovery.dto.FreeReplyDto">
         SELECT
             r.reply_id, r.free_id, r.member_id,
             r.content, r.parent_id, r.created_at,
-            m.nick_name
+            m.nickname
         FROM free_reply r
         JOIN member m ON r.member_id = m.member_id
         WHERE r.free_id = #{freeId}
@@ -79,9 +81,12 @@
         WHERE free_id = #{freeId}
     </select>
 
-
-
-
+    <!-- 특정 부모 댓글 대댓글 수 조회-->
+    <select id="getChildReplyCount" resultType="int">
+        SELECT COUNT(*)
+        FROM free_reply
+        WHERE parent_id = #{parentId}
+    </select>
 
 
 

--- a/ecovery/src/test/java/com/ecovery/mapper/FreeImgMapperTest.java
+++ b/ecovery/src/test/java/com/ecovery/mapper/FreeImgMapperTest.java
@@ -36,9 +36,9 @@ class FreeImgMapperTest {
         // Given(준비) : 새로 등록할 이미지 정보 생성
         FreeImgVO vo = FreeImgVO.builder()
                 .freeId(2L)
-                .imgName("test4_image")
-                .oriImgName("test4.jpg")
-                .imgUrl("/images/test4_image.jpg")
+                .imgName("test2_image")
+                .oriImgName("test2.jpg")
+                .imgUrl("/images/test2_image.jpg")
                 .repImgYn("N")
                 .createdAt(LocalDateTime.now())
                 .build();
@@ -53,8 +53,8 @@ class FreeImgMapperTest {
         List<FreeImgDto> list = freeImgMapper.getFreeImgList(2L);
         FreeImgDto dto = list.get(list.size() - 1); // 가장 마지막 이미지가 방금 insert한 이미지..
 
-        assertEquals("test4_image", dto.getImgName());
-        assertEquals("test4.jpg", dto.getOriImgName());
+        assertEquals("test2_image", dto.getImgName());
+        assertEquals("test2.jpg", dto.getOriImgName());
         log.info("등록된 이미지 : {}", dto);
     }
 
@@ -115,7 +115,7 @@ class FreeImgMapperTest {
     public void testDelete() {
 
         Long freeId = 2L; // 게시글 ID
-        Long targetFreeImgId = 1L; // 삭제하고 싶은 이미지의 ID (예: 사용자가 선택한 이미지)
+        Long targetFreeImgId = 4L; // 삭제하고 싶은 이미지의 ID (예: 사용자가 선택한 이미지)
 
         // 해당 이미지 정보 조회
         List<FreeImgDto> imageList = freeImgMapper.getFreeImgList(freeId);
@@ -141,7 +141,22 @@ class FreeImgMapperTest {
         }
     }
 
+    @Test
+    @DisplayName("대표 이미지 조회 테스트")
+    public void testGetRepImg(){
 
+        // Given : 대표 이미지가 존재하는 게시글 ID
+        Long freeId = 7L;
+
+        // When : 대표 이미지 조회 메소드 실행
+        FreeImgDto repImg = freeImgMapper.getRepImg(freeId);
+
+        // Then : 결과 검증
+        assertNotNull(repImg, "대표 이미지가 존재해야 합니다.");
+        assertEquals("Y", repImg.getRepImgYn(), "대표 이미지 플래그는 'Y'여야 합니다.");
+        
+        log.info("대표 이미지 정보 : {}", repImg);
+    }
 
 }
 

--- a/ecovery/src/test/java/com/ecovery/mapper/FreeMapperTest.java
+++ b/ecovery/src/test/java/com/ecovery/mapper/FreeMapperTest.java
@@ -48,7 +48,7 @@ class FreeMapperTest {
         vo.setItemCondition(ItemCondition.LOW);
 
         // When (실행)
-        freeMapper.insertSelectKey(vo);
+        freeMapper.insert(vo);
 
         // Then (검증)
         // 1) insert 후 FreeId가 자동으로 채워졌는지
@@ -94,7 +94,7 @@ class FreeMapperTest {
     public void testDelete(){
 
         //Given : 삭제할 게시글 ID가 존재함
-        Long targetId = 5L;
+        Long targetId = 2L;
 
         //When : 게시글 삭제 요청 실행
         int deletedCount = freeMapper.delete(targetId);

--- a/ecovery/src/test/java/com/ecovery/mapper/FreeReplyMapperTest.java
+++ b/ecovery/src/test/java/com/ecovery/mapper/FreeReplyMapperTest.java
@@ -1,32 +1,181 @@
-//package com.ecovery.mapper;
-//
-//import com.ecovery.domain.FreeReplyVO;
-//import lombok.extern.slf4j.Slf4j;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.context.SpringBootTest;
-//
-//import static org.junit.jupiter.api.Assertions.*;
-//
-//@SpringBootTest
-//@Slf4j
-//class FreeReplyMapperTest {
-//
-//    @Autowired
-//    private FreeReplyMapper freeReplyMapper;
-//
-//    @Test
-//    public void testInsertReply() {
-//        FreeReplyVO vo = new FreeReplyVO();
-//        vo.setFreeId(1L);               // 게시글 ID
-//        vo.setMemberId(2L);             // 작성자 ID
-//        vo.setContent("댓글 테스트");
-//        vo.setParentId(null);           // 일반 댓글 (null) 또는 대댓글일 경우 부모 ID
-//        // createdAt은 DB에서 NOW()로 자동 처리
-//
-//        freeReplyMapper.insert(vo);     // Mapper 호출
-//
-//        log.info("삽입된 댓글 ID = {}", vo.getReplyId()); // @Options가 설정된 경우에만 값 확인 가능
-//    }
-//}
-//
+package com.ecovery.mapper;
+
+import com.ecovery.domain.FreeReplyVO;
+import com.ecovery.dto.FreeReplyDto;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ * 무료나눔 댓글 Mapper 테스트
+ * FreeReplyMapper의 댓글 및 대댓글 crud 기능 정상작동 여부 단위테스트
+ *
+ * 일반 댓글 및 대댓글 등록 테스트
+ * 특정 댓글 및 게시글 전체 댓글 수 조회 테스트
+ * 댓글/대댓글 수정 테스트
+ * 댓글 삭제시 Cascade 설정을 통한 대댓글 자동 삭제 테스트 포함
+ *
+ * @author : yeonsu
+ * @fileName : FreeReplyMapperTest
+ * @since : 250716
+ */
+
+@SpringBootTest
+@Slf4j
+class FreeReplyMapperTest {
+
+    @Autowired
+    private FreeReplyMapper freeReplyMapper;
+
+    @Test
+    @DisplayName("일반 댓글 등록 테스트")
+    public void testInsertReply() {
+
+        // Given : 새로 등록할 댓글 정보 생성
+        FreeReplyVO vo = FreeReplyVO.builder()
+                .freeId(7L) // 게시글 ID
+                .memberId(2L) // 작성자 ID
+                .content("추가됐니")
+                .parentId(null) // 일반 댓글 (대댓글은 부모ID 입력)
+                .build();
+        // createdAT은 DB에서 자동 처리
+
+        // When : 댓글 등록 메소드 호출
+        freeReplyMapper.insert(vo);     // Mapper 호출
+
+        // Then : 결과확인 (replyId가 생성되었는지 확인)
+        assertNotNull(vo.getReplyId(), "댓글ID가 null이면 안됩니다.");
+        log.info("삽입된 댓글 ID = {}", vo.getReplyId()); // @Options가 설정된 경우에만 값 확인 가능
+    }
+
+    @Test
+    @DisplayName("대댓글 등록 테스트")
+    public void testInsertChildReply() {
+
+        // Given : 대댓글 정보를 생성 (free_id, member_id, content, parent_id 필수)
+        FreeReplyVO childReply = FreeReplyVO.builder()
+                .freeId(7L)   // 대댓글이 달릴 게시글 ID
+                .memberId(2L) // 작성자 ID
+                .content("대댓글2 테스트")
+                .parentId(6L) // 대댓글이 달릴 부모 댓글 ID (reply_id)
+                .build();
+
+        // When : 대댓글 등록
+        freeReplyMapper.insert(childReply);
+
+        // Then : 대댓글 ID가 정상 생성되었는지 확인
+        assertNotNull(childReply.getReplyId(), "대댓글 ID가 null이면 안됩니다.");
+        log.info("등록된 대댓글 ID = {}", childReply.getReplyId());
+    }
+
+    @Test
+    @DisplayName("일반 댓글 조회 테스트")
+    public void testGetReply() {
+
+        // Given : 특정 게시글 ID에 댓글이 1개 이상 있다고 가정
+        Long replyId = 4L;
+
+        // When : 게시글 ID로 댓글 목록 조회
+        FreeReplyDto list = freeReplyMapper.read(replyId);
+
+        // Then : 결과 검증
+        assertNotNull(list, "댓글이 존재해야 합니다.");
+        assertEquals(replyId, list.getReplyId(), "조회된 댓글 ID가 일치해야 합니다.");
+
+        log.info("조회된 댓글 정보 : {}", list);
+    }
+
+    @Test
+    @DisplayName("특정 게시글 댓글 수 조회 테스트 ")
+    public void testGetTotalReplyCount() {
+
+        // Given : 댓글 수를 조회할 게시글 ID
+        Long freeId = 4L;
+
+        // When : 해당 게시글의 전체 댓글 수 조회
+        int totalCount = freeReplyMapper.getTotalReplyCount(freeId);
+
+        // Then : 결과 출력
+        if (totalCount > 0) {
+            log.info("총 댓글 수 : {}", totalCount);
+        } else {
+            log.info("해당 게시글에는 댓글이 없습니다.");
+        }
+    }
+
+    @Test
+    @DisplayName("일반 댓글 수정 테스트")
+    public void testUpdateReply() {
+
+        // Given : 이미 존재하는 댓글 ID
+        Long replyId = 6L;
+
+        // When : 해당 댓글 내용을 수정
+        FreeReplyVO vo = FreeReplyVO.builder()
+                .replyId(replyId)
+                .content("수정됐니")
+                .build();
+        int Count = freeReplyMapper.update(vo);
+
+        // Then : 수정 결과 확인
+        assertEquals(1, Count, "수정된 행이 1개여야 합니다");
+
+        // 수정된 내용 확인
+        FreeReplyDto dto = freeReplyMapper.read(replyId);
+        assertEquals("수정됐니", dto.getContent());
+        log.info("수정된 댓글 내용 : {}", dto.getContent());
+    }
+
+    @Test
+    @DisplayName("대댓글 수정 테스트")
+    public void testGetChildReply() {
+
+        // Given : 수정할 대댓글 ID
+        Long replyId = 7L;
+
+        // When : 해당 대댓글 내용 수정
+        FreeReplyVO vo = FreeReplyVO.builder()
+                .replyId(replyId)
+                .content("대댓글 수정")
+                .build();
+        int result = freeReplyMapper.update(vo);
+
+        // Then : 수정 성공 여부 및 내용 확인
+        assertEquals(1, result, "수정된 행 수는 1개여야 합니다.");
+
+        FreeReplyDto dto = freeReplyMapper.read(replyId);
+        assertEquals("대댓글 수정", dto.getContent());
+        log.info("수정된 대댓글 내용 : {}", dto.getContent());
+
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 테스트")
+    public void testDeleteReply() {
+
+        // Given : 삭제할 댓글 ID가 존재함
+        Long replyId = 6L;
+
+        // When : 댓글이 부모댓글이라면 대댓글 수 확인 후 삭제
+        int childCount = freeReplyMapper.getChildReplyCount(replyId);
+        int deletedCount = freeReplyMapper.delete(replyId); // 부모만 삭제(대댓글은 cascade로 자동삭제)
+
+        // Then : 삭제 결과 확인
+        log.info("삭제된 대댓글 수 : {}", childCount);
+        log.info("총 삭제된 댓글 수 : {}", childCount + deletedCount);
+
+        if (deletedCount > 0) {
+            log.info("댓글 삭제 테스트 성공 ");
+        } else {
+            log.info(" 댓글 삭제 테스트 실패: 댓글이 존재하지 않음", replyId);
+        }
+
+
+    }
+
+}
+


### PR DESCRIPTION
2025-07-16 (수) mappertest0716-yeonsu
1. 무료나눔 이미지 테이블에 free_id 외래키 설정 변경 
-> 게시글 삭제시, 연결된 이미지들도 함께 삭제되도록 설정 변경했음 

CONSTRAINT fk_free_img_free 
 FOREIGN KEY (free_id) REFERENCES free(free_id) ON DELETE CASCADE

2. 무료나눔 댓글 테이블에도 free_id 외래키 설정 변경 
-> 게시글 삭제시, 연결된 댓글들도 함께 삭제되도록 설정 변경했음 

3. 무료나눔 댓글 테이블에서 parent_id에 외래키 설정
ALTER TABLE free_reply
ADD CONSTRAINT fk_parent_reply
FOREIGN KEY (parent_id) REFERENCES free_reply(reply_id)
ON DELETE CASCADE;
-> 이 코드 작성해서 일반댓글(부모댓글) 삭제될 때 
해당 reply_id를 parent_id로 참조하는 모든 대댓글(자식댓글)이 자동으로 삭제됨
 
4. 특정 게시글에서 해당 댓글에 달린 대댓글의  갯수는 화면에 보여주지 않을거라서 안씀
(특정 게시글의 일반 댓글 수 조회하는 코드 쓰다가 같이하려고했는데 ,, 너무 추가할 거 많아져서 개선사항..하던가)

5. 일단 오늘기준으로 mappertest까지해서 mapper부분은 끝 ! 
이제 서비스 구현차례..