### PR TITLE
[20250728] 환경톡톡 게시판 이미지 추가 테스트 완료

### DIFF
--- a/DB 2차 정리.txt
+++ b/DB 2차 정리.txt
@@ -238,9 +238,9 @@ CREATE TABLE env (
 CREATE TABLE env_img (
     env_img_id BIGINT AUTO_INCREMENT PRIMARY KEY,
     env_id BIGINT NOT NULL,
-    img_name VARCHAR(255) NOT NULL,
+    img_name VARCHAR(255),
     ori_img_name VARCHAR(255),
-    img_url VARCHAR(500) NOT NULL,
+    img_url VARCHAR(500)
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (env_id) REFERENCES env(env_id) ON DELETE CASCADE
 );

--- a/ecovery/src/main/java/com/ecovery/controller/MemberController.java
+++ b/ecovery/src/main/java/com/ecovery/controller/MemberController.java
@@ -17,6 +17,9 @@ import com.ecovery.domain.MemberVO;
  * 회원가입, 로그인를 위한 Controller
  * 회원가입 시 정보를 DB에 저장하고 회원정보 수정, 목록 조회, 중복검증 가능
  * 작성자 : 방희경
+ * @history
+      - 250728 | yukyeong | 일반 회원가입 시 provider 값이 null로 들어가 DB 제약조건 오류 발생
+                            → provider='local', providerId=null 명시적으로 설정하여 해결
  */
 @Controller
 @RequiredArgsConstructor

--- a/ecovery/src/main/java/com/ecovery/dto/EnvDto.java
+++ b/ecovery/src/main/java/com/ecovery/dto/EnvDto.java
@@ -1,9 +1,7 @@
 package com.ecovery.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -23,6 +21,9 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class EnvDto {
 
     private Long envId; // 환경 톡톡 게시글 ID

--- a/ecovery/src/main/java/com/ecovery/dto/EnvFormDto.java
+++ b/ecovery/src/main/java/com/ecovery/dto/EnvFormDto.java
@@ -1,0 +1,41 @@
+package com.ecovery.dto;
+
+import jakarta.validation.Valid;
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 환경톡톡 게시글 등록/수정용 Form DTO
+ * - 게시글 정보(EnvDto)와 이미지 ID 목록을 함께 전달받기 위한 용도
+ * - REST API에서 @RequestPart로 multipart/form-data를 처리할 때 사용됨
+ *
+ * @author : yukyeong
+ * @fileName : EnvFormDto
+ * @since : 250728
+ * @history
+     - 250728 | yukyeong | 게시글 등록 및 수정용 EnvFormDto 생성 (EnvDto + 이미지 리스트)
+ */
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EnvFormDto {
+
+    @Valid
+    private EnvDto envDto; // 게시글 본문 정보
+
+    private List<Long> deleteImgIds = new ArrayList<>(); // 이미지 수정. 삭제용 ID 리스트
+
+    private List<MultipartFile> envImgFiles = new ArrayList<>(); // 이미지 파일들 추가
+
+    public EnvFormDto(EnvDto envDto) {
+        this.envDto = envDto;
+        this.envImgFiles = new ArrayList<>(); // null 방지 초기화
+    }
+}

--- a/ecovery/src/main/java/com/ecovery/service/EnvService.java
+++ b/ecovery/src/main/java/com/ecovery/service/EnvService.java
@@ -3,6 +3,8 @@ package com.ecovery.service;
 import com.ecovery.domain.EnvVO;
 import com.ecovery.dto.Criteria;
 import com.ecovery.dto.EnvDto;
+import com.ecovery.dto.EnvFormDto;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -17,15 +19,18 @@ import java.util.List;
      - 250715 | yukyeong | EnvService 인터페이스 최초 작성 (CRUD, 페이징)
      - 250716 | yukyeong | 조회수 증가 추가
      - 250718 | yukyeong | VO를 DTO로 변경
+     - 250728 | yukyeong | 이미지 포함 게시글 등록 및 수정 메서드로 변경 (EnvFormDto + MultipartFile)
  */
 
 public interface EnvService {
 
-    public void register(EnvDto envDto); // 게시글 등록 (DTO로 등록)
+    // 게시글 등록 (본문 + 이미지 파일)
+    public void register(EnvFormDto envFormDto, List<MultipartFile> envImgFiles) throws Exception;
 
     public EnvDto get(Long envId); // 게시글 단건 조회 (DTO 반환)
 
-    public boolean modify(EnvDto envDto); // 게시글 수정 (DTO로 수정)
+    // 게시글 수정 (본문 + 이미지 ID 목록 + 새 이미지 파일)
+    public boolean modify(EnvFormDto envFormDto, List<MultipartFile> envImgFiles) throws Exception;
 
     public boolean remove(Long envId); // 게시글 삭제 (삭제는 ID만으로)
 

--- a/ecovery/src/main/resources/mapper/EnvImgMapper.xml
+++ b/ecovery/src/main/resources/mapper/EnvImgMapper.xml
@@ -10,7 +10,7 @@
     @fileName : EnvImgMapper.xml
     @since : 250726
     @history
-     - 250725 | yukyeong | 이미지 등록/조회/삭제 쿼리 작성
+     - 250726 | yukyeong | 이미지 등록/조회/삭제 쿼리 작성
 -->
 
 <mapper namespace="com.ecovery.mapper.EnvImgMapper">

--- a/ecovery/src/test/java/com/ecovery/controller/EnvApiControllerTest.java
+++ b/ecovery/src/test/java/com/ecovery/controller/EnvApiControllerTest.java
@@ -1,6 +1,7 @@
 package com.ecovery.controller;
 
 import com.ecovery.dto.EnvDto;
+import com.ecovery.dto.EnvFormDto;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -10,12 +11,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -28,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * REST API 컨트롤러의 주요 기능(목록 조회, 등록, 수정, 삭제)에 대해 통합 테스트 수행
  * MockMvc를 사용하여 HTTP 요청/응답 시나리오를 시뮬레이션
  * @author : yukyeong
- * @fileName : EnvApiControllerTest.java
+ * @fileName : EnvApiControllerTest
  * @since : 250722
  * @history
      - 250722 | yukyeong | 게시글 목록 조회 API 테스트 (검색 조건 포함/없음) 구현
@@ -37,6 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
      - 250722 | yukyeong | 게시글 삭제 API 테스트 (정상 삭제 케이스) 구현
      - 250724 | yukyeong | 공지사항 단건조회 성공, 등록/수정/단건조회/삭제 실패 테스트 케이스 추가 (유효성 검증 및 존재하지 않는 ID)
      - 250725 | yukyeong | 게시글 등록/수정 통합 테스트에 category 필드 테스트 추가
+     - 250728 | yukyeong | 게시글 등록/수정 multipart 구조 대응 테스트 및 이미지 교체 테스트 추가
  */
 
 @SpringBootTest
@@ -95,35 +100,89 @@ class EnvApiControllerTest {
     @Test
     @DisplayName("API 컨트롤러 - 게시글 등록 성공 테스트")
     @WithMockUser(username = "test@test.com", roles = {"ADMIN"})
-    public void testRegister() throws Exception {
-        // Given - 게시글 제목/내용
-        EnvDto dto = new EnvDto(); // 게시글 DTO 객체 생성
-        dto.setTitle("API 통합 테스트 제목"); // 제목 설정
-        dto.setContent("API 통합 테스트 내용"); // 내용 설정
-        dto.setCategory("news"); // category 추가
+    public void testRegisterWithMultipart() throws Exception {
+        // Given - 게시글 본문 DTO
+        EnvDto dto = new EnvDto();
+        dto.setTitle("테스트 제목");
+        dto.setContent("테스트 내용");
+        dto.setCategory("news");
 
-        // ObjectMapper를 사용해 DTO 객체를 JSON 문자열로 변환
-        // 실제 컨트롤러가 @RequestBody로 JSON을 받을 것이기 때문에 이 형식으로 요청을 보냄
-        String json = objectMapper.writeValueAsString(dto);
+        EnvFormDto formDto = new EnvFormDto(dto);
 
-        // When - mockMvc를 사용하여 컨트롤러에 POST 요청 수행
-        MvcResult result = mockMvc.perform(post("/api/env/register") // 요청 경로: POST /api/env/register
-                        .contentType(MediaType.APPLICATION_JSON) // 요청 본문의 타입을 application/json으로 지정
-                        .content(json) // 변환된 JSON 데이터를 요청 본문에 포함
-                        .with(csrf())) // CSRF 토큰 추가 (Spring Security에서 필수)
-                .andExpect(MockMvcResultMatchers.status().isCreated()) // 기대하는 응답 상태: 201 Created
-                .andReturn(); // 결과(MvcResult) 반환
+        // JSON 직렬화 (envFormDto → JSON)
+        String json = objectMapper.writeValueAsString(formDto);
 
-        // Then - 응답 결과(JSON 문자열)를 출력해서 실제 반환 값을 확인
-        String response = result.getResponse().getContentAsString(); // 응답 본문을 문자열로 추출
-        log.info("====> 응답 본문: " + response);  // 응답 내용 로그 출력 (예: {"envId":63})
+        // JSON을 MockMultipartFile로 변환
+        MockMultipartFile jsonPart = new MockMultipartFile(
+                "envFormDto", // @RequestPart name
+                "envFormDto", // original filename (무관)
+                "application/json", // content type
+                json.getBytes(StandardCharsets.UTF_8) // content
+        );
 
+        // 이미지 파일이 없어도 테스트 가능 (빈 파일 전송)
+        MockMultipartFile emptyImage = new MockMultipartFile(
+                "envImgFiles",     // @RequestPart name
+                "empty.jpg",       // filename
+                "image/jpeg",      // content type
+                new byte[0]        // 빈 파일
+        );
+
+        // When & Then
+        mockMvc.perform(multipart("/api/env/register")
+                        .file(jsonPart)
+                        .file(emptyImage)
+                        .with(csrf()))
+                .andExpect(status().isCreated())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("API 컨트롤러 - 게시글 + 이미지 등록 성공 테스트")
+    @WithMockUser(username = "test@test.com", roles = {"ADMIN"})
+    public void testRegisterWithImage() throws Exception {
+        // Given - 게시글 본문 DTO
+        EnvDto dto = new EnvDto();
+        dto.setTitle("테스트 제목");
+        dto.setContent("테스트 내용");
+        dto.setCategory("news");
+
+        EnvFormDto formDto = new EnvFormDto(dto);
+
+        // JSON 직렬화 (envFormDto → JSON)
+        String json = objectMapper.writeValueAsString(formDto);
+
+        // JSON 본문을 multipart 파일로 변환
+        MockMultipartFile jsonPart = new MockMultipartFile(
+                "envFormDto", // @RequestPart name
+                "envFormDto", // original filename
+                "application/json",
+                json.getBytes(StandardCharsets.UTF_8)
+        );
+
+        // 실제 이미지 파일 (테스트용 임의 데이터)
+        byte[] imageBytes = "fake image content".getBytes(StandardCharsets.UTF_8);
+
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "envImgFiles", // @RequestPart name
+                "test-image.jpg", // 이미지 이름
+                "image/jpeg", // 이미지 타입
+                imageBytes // 이미지 바이트
+        );
+
+        // When & Then
+        mockMvc.perform(multipart("/api/env/register")
+                        .file(jsonPart)
+                        .file(imageFile)
+                        .with(csrf()))
+                .andExpect(status().isCreated())
+                .andDo(print());
     }
 
     // 게시글 등록 실패 테스트 (유효성 실패)
     @Test
     @DisplayName("게시글 등록 실패 - 제목 없음")
-    @WithMockUser(username = "admin@test.com", roles = {"ADMIN"})
+    @WithMockUser(username = "test@test.com", roles = {"ADMIN"})
     public void testRegisterFail() throws Exception {
 
         // Given - 제목이 비어 있는 DTO 객체 생성
@@ -177,53 +236,182 @@ class EnvApiControllerTest {
 
 
     @Test
-    @DisplayName("API 컨트롤러 - 게시글 수정 성공 테스트")
-    @WithMockUser(username = "admin@test.com", roles = {"ADMIN"})
-    public void testModify() throws Exception {
-        // Given - 수정할 게시글 데이터 (게시글 ID가 DB에 실제로 존재해야 함)
+    @DisplayName("API 컨트롤러 - 게시글 수정 성공 테스트 (이미지 없음)")
+    @WithMockUser(username = "test@test.com", roles = {"ADMIN"})
+    public void testModifyWithMultipart() throws Exception {
+        // Given - 수정 대상 게시글 정보를 DTO로 생성
         EnvDto dto = new EnvDto();
-        dto.setEnvId(11L); // 기존 게시글 ID
-        dto.setTitle("수정된 제목입니다"); // 수정할 제목
-        dto.setContent("수정된 내용입니다"); // 수정할 내용
-        dto.setCategory("tips"); // category 추가
+        dto.setEnvId(11L); // 실제 DB에 존재하는 게시글 ID
+        dto.setTitle("수정된 제목입니다");
+        dto.setContent("수정된 내용입니다");
+        dto.setCategory("tips");
 
-        // EnvDto 객체를 JSON 문자열로 변환 (HTTP 요청 본문에 담기 위해)
-        String json = objectMapper.writeValueAsString(dto);
+        // 위에서 작성한 EnvDto를 EnvFormDto에 래핑 (컨트롤러는 EnvFormDto를 받음)
+        EnvFormDto formDto = new EnvFormDto(dto);
 
-        // When & Then - 수정 API 호출 및 응답 검증
-        mockMvc.perform(put("/api/env/modify/11") // 요청 URI (PUT 방식)
-                        .contentType(MediaType.APPLICATION_JSON) // 요청 본문 타입 설정
-                        .content(json) // JSON 데이터 전송
-                        .with(csrf())) // CSRF 토큰 포함
-                .andExpect(status().isOk()) // 응답 상태 코드가 200 OK인지 검증
-                .andExpect(jsonPath("$.message").value("수정 성공")) // 응답 JSON의 message 값 검증
-                .andExpect(jsonPath("$.envId").value(11L)); // 응답 JSON의 envId 값 검증
+        // EnvFormDto를 JSON 문자열로 직렬화
+        String json = objectMapper.writeValueAsString(formDto);
+
+        // JSON 문자열을 multipart/form-data 요청에 포함시키기 위해 MockMultipartFile로 변환
+        // 컨트롤러의 @RequestPart("form")과 이름이 반드시 일치해야 함
+        MockMultipartFile jsonPart = new MockMultipartFile(
+                "envFormDto", // part 이름: 컨트롤러 @RequestPart("envFormDto")과 동일해야 함
+                "form.json", // 실제 파일 이름 (테스트에서 중요하지 않음)
+                "application/json", // 컨텐츠 타입
+                json.getBytes(StandardCharsets.UTF_8) // JSON 데이터를 바이트로 변환
+        );
+
+        // 이미지가 없는 경우에도 multipart 형식을 유지하기 위해 빈 파일 전송
+        // part 이름은 컨트롤러의 @RequestPart("envImgFiles")과 일치해야 함
+        MockMultipartFile dummyImg = new MockMultipartFile(
+                "envImgFiles", // part 이름
+                "empty.jpg", // 파일 이름
+                "image/jpeg", // 컨텐츠 타입
+                new byte[0]); // 내용 없음 (빈 파일)
+
+        // When & Then - multipart 요청 전송
+        mockMvc.perform(multipart("/api/env/modify/{envId}", 11L) // PUT 요청 URL 지정
+                        .file(jsonPart) // JSON 본문 포함
+                        .file(dummyImg) // 빈 이미지 파일 포함
+                        .with(csrf()) // CSRF 토큰 포함
+                        .with(request -> { // multipart는 기본 POST이므로 PUT으로 강제 설정
+                            request.setMethod("PUT");
+                            return request;
+                        }))
+                .andExpect(status().isOk()) // 200 OK 응답을 기대
+                .andExpect(jsonPath("$.message").value("수정 성공")) // JSON 응답 필드 message가 "수정 성공"인지 검증
+                .andExpect(jsonPath("$.envId").value(11L)); // 응답에 반환된 envId가 11L인지 검증
     }
+
+
+    @Test
+    @DisplayName("게시글 이미지 교체 테스트 (등록 후 수정)")
+    @WithMockUser(username = "test@test.com", roles = {"ADMIN"})
+    public void testImageReplaceAfterRegister() throws Exception {
+        // Given - 게시글 등록 + 초기 이미지
+        EnvDto dto = new EnvDto();
+        dto.setTitle("초기 이미지 등록");
+        dto.setContent("기존 이미지 등록용");
+        dto.setCategory("news");
+
+        // EnvFormDto로 변환
+        EnvFormDto formDto = new EnvFormDto(dto);
+
+        // JSON으로 변환한 게시글 폼 데이터를 multipart 형식으로 구성
+        String json = objectMapper.writeValueAsString(formDto);
+        MockMultipartFile jsonPart = new MockMultipartFile(
+                "envFormDto", // 컨트롤러에서 받는 필드명과 일치해야 함
+                "form.json",
+                "application/json",
+                json.getBytes());
+
+        // 첨부할 이미지 파일 1개 준비
+        MockMultipartFile image = new MockMultipartFile(
+                "envImgFiles",  // 컨트롤러에서 받는 이미지 리스트 이름
+                "img1.jpg",
+                "image/jpeg",
+                "test image".getBytes());
+
+        // When - 게시글 등록 요청 수행
+        MvcResult result = mockMvc.perform(multipart("/api/env/register")
+                        .file(jsonPart) // form 데이터
+                        .file(image) // 이미지
+                        .with(csrf())) // CSRF 토큰 포함
+                .andExpect(status().isCreated()) // 201 응답 기대
+                .andReturn(); // 결과 반환
+
+        // Then - 등록된 게시글의 envId 추출
+        String response = result.getResponse().getContentAsString();
+        JsonNode node = objectMapper.readTree(response);
+        Long envId = node.get("envId").asLong(); // 등록된 게시글 ID
+
+
+        // Given - 수정할 게시글 정보 및 새 이미지
+        dto.setEnvId(envId); // 기존 게시글 ID 세팅
+        dto.setTitle("수정 제목");
+        dto.setContent("수정 내용");
+
+        EnvFormDto modifyForm = new EnvFormDto(dto);
+        String modifyJson = objectMapper.writeValueAsString(modifyForm);
+
+        // 수정용 form 데이터 (application/json)
+        MockMultipartFile form = new MockMultipartFile(
+                "envFormDto",
+                "form.json",
+                "application/json",
+                modifyJson.getBytes());
+
+        // 교체할 새로운 이미지 파일 준비
+        MockMultipartFile newImage = new MockMultipartFile(
+                "envImgFiles",
+                "newImg.jpg",
+                "image/jpeg",
+                "new image".getBytes());
+
+        // When - PUT 방식으로 게시글 수정 요청
+        mockMvc.perform(multipart("/api/env/modify/" + envId)
+                        .file(form) // 수정할 폼 데이터
+                        .file(newImage) // 새 이미지 파일
+                        .with(csrf()) // CSRF 토큰
+                        .with(request -> { // PUT 방식으로 강제 지정
+                            request.setMethod("PUT");
+                            return request;
+                        }))
+                // Then - 수정 성공 응답 확인
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.envId").value(envId))
+                .andExpect(jsonPath("$.message").value("수정 성공"))
+                .andDo(print());
+    }
+
 
     // 게시글 수정 실패 테스트 (존재하지 않는 ID)
     @Test
     @DisplayName("게시글 수정 실패 - 존재하지 않는 ID")
-    @WithMockUser(username = "admin@test.com", roles = {"ADMIN"})
+    @WithMockUser(username = "test@test.com", roles = {"ADMIN"})
     public void testModifyFail_NotFound() throws Exception {
-        // Given - 존재하지 않는 게시글 ID와 수정 데이터
-        Long invalidId = 99999L; // 존재하지 않는 ID
+        // Given - 존재하지 않는 게시글 ID
+        Long invalidId = 99999L;
 
-        // 수정할 게시글 데이터 설정
+        // 게시글 데이터 생성
         EnvDto dto = new EnvDto();
         dto.setTitle("수정 테스트 제목");
         dto.setContent("수정 테스트 내용");
+        dto.setCategory("news");
 
-        // DTO를 JSON 문자열로 변환 (Controller가 @RequestBody로 JSON을 받기 때문)
-        String json = objectMapper.writeValueAsString(dto);
+        // EnvFormDto 래핑
+        EnvFormDto formDto = new EnvFormDto(dto);
+
+        // EnvFormDto → JSON 직렬화 (multipart 요청에서 JSON part로 사용)
+        String json = objectMapper.writeValueAsString(formDto);
+        MockMultipartFile formPart = new MockMultipartFile(
+                "envFormDto", // @RequestPart 이름
+                "form.json",
+                "application/json",
+                json.getBytes(StandardCharsets.UTF_8)
+        );
+
+        // 이미지 첨부는 필수가 아니므로 빈 파일로 대체 (null 방지)
+        MockMultipartFile dummyImg = new MockMultipartFile(
+                "envImgFiles",
+                "empty.jpg",
+                "image/jpeg",
+                new byte[0]
+        );
 
         // When & Then - 수정 API 호출 → 응답 검증
-        mockMvc.perform(put("/api/env/modify/{enveId}", invalidId) // PUT 요청
-                        .contentType(MediaType.APPLICATION_JSON) // 요청 본문은 JSON 형식
-                        .content(json) // JSON 본문 데이터 전송
-                        .with(csrf())) // CSRF 토큰 포함
-                .andDo(print()) // 요청/응답 로그 출력
-                .andExpect(status().isBadRequest()) // 응답 상태가 400 (Bad Request) 인지 확인
-                .andExpect(content().string("수정에 실패했습니다."));  // 응답 본문 메시지 확인 (예상 메시지와 일치하는지)
+        // multipart()를 사용하여 PUT 요청 강제 설정
+        mockMvc.perform(multipart("/api/env/modify/{envId}", invalidId) // 존재하지 않는 ID로 요청
+                        .file(formPart) // 게시글 JSON part
+                        .file(dummyImg) // 이미지 파일 part
+                        .with(csrf()) // CSRF 토큰 포함 (보안 설정)
+                        .with(request -> { // multipart는 기본이 POST이므로 PUT으로 강제 설정
+                            request.setMethod("PUT");
+                            return request;
+                        }))
+                .andExpect(status().isBadRequest()) // 기대 결과: 400 Bad Request 응답
+                .andExpect(content().string("수정에 실패했습니다.")) // 반환 메시지 확인
+                .andDo(print());
     }
 
 

--- a/ecovery/src/test/java/com/ecovery/service/EnvImgServiceTest.java
+++ b/ecovery/src/test/java/com/ecovery/service/EnvImgServiceTest.java
@@ -1,6 +1,7 @@
 package com.ecovery.service;
 
 import com.ecovery.dto.EnvDto;
+import com.ecovery.dto.EnvFormDto;
 import com.ecovery.dto.EnvImgDto;
 import com.ecovery.mapper.EnvImgMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -10,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,15 +20,17 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * EnvImgServiceTest
- * - 환경톡톡 게시판의 이미지 관련 기능(등록, 조회, 삭제)에 대한 단위 테스트 클래스
- * - EnvImgService 구현체에 대한 통합 테스트 수행
+ * - 환경톡톡 게시판의 이미지 관련 기능(등록, 조회, 삭제, 수정)에 대한 단위 테스트 클래스
+ * - EnvImgService 구현체 및 EnvService 연동 통합 테스트 수행
  * - 테스트를 위해 게시글(EnvDto)과 이미지(EnvImgDto)를 함께 사용
  *
  * @author   : yukyeong
- * @fileName : EnvImgServiceTest.java
- * @since    : 2025-07-26
+ * @fileName : EnvImgServiceTest
+ * @since    : 250726
  * @history
-    - 2025-07-26 | yukyeong | 이미지 등록, 목록 조회, 단일 삭제, 전체 삭제 테스트 구현
+    - 250726 | yukyeong | 이미지 등록, 목록 조회, 단일 삭제, 전체 삭제 테스트 구현
+    - 250728 | yukyeong | EnvFormDto 기반 게시글 + 이미지 등록 방식으로 테스트 전체 수정
+                          게시글 수정 시 이미지 일부 삭제 테스트 추가
  */
 
 @SpringBootTest
@@ -47,74 +51,90 @@ class EnvImgServiceTest {
     @DisplayName("이미지 등록 테스트")
     @Transactional
     public void testRegister() throws Exception{
-        // Given - 1. 테스트용 게시글 등록
+
+        // Given - 테스트 준비 단계
+        // 1. 테스트용 게시글 객체 생성
         EnvDto envDto = new EnvDto();
-        envDto.setMemberId(1L);
-        envDto.setTitle("이미지 테스트 게시글");
-        envDto.setContent("이미지 등록 전용 게시글");
-        envDto.setCategory("tip");
-        envService.register(envDto);
-        Long envId = envDto.getEnvId();
-        assertNotNull(envId);
+        envDto.setMemberId(1L); // 테스트용 회원 ID 설정 (DB에 1번 회원이 존재해야 함)
+        envDto.setTitle("이미지 테스트 게시글"); // 게시글 제목 설정
+        envDto.setContent("이미지 등록 전용 게시글"); // 게시글 본문 내용 설정
+        envDto.setCategory("tip"); // 게시글 카테고리 설정
 
-        // Given - 2. 테스트용 이미지 DTO 생성
-        EnvImgDto imgDto = EnvImgDto.builder()
-                .envId(envId)
-                .build();
-
+        // 2. Mock 이미지 파일 생성 (가짜 파일) - 실제 업로드 파일처럼 테스트용으로 메모리상에서 가상 이미지 파일 생성
         MockMultipartFile mockFile = new MockMultipartFile(
-                "imgFile",
-                "sample.jpg",
-                "image/jpeg",
-                "fake image content".getBytes()
+                "imgFile",  // form 필드 이름 (서비스에서 받는 필드명과 일치해야 함)
+                "sample.jpg", // 원본 파일명
+                "image/jpeg", // MIME 타입
+                "fake image content".getBytes() // 파일 내용 (바이트 배열 형태로 전달)
         );
 
-        // When - 이미지 등록
-        envImgService.register(imgDto, mockFile); // 이미지 등록 수행
+        // 3. EnvFormDto 생성 (게시글 + 이미지 ID를 담는 Form 객체) - 실제 컨트롤러에서 사용하는 구조와 유사하게 감쌈
+        EnvFormDto formDto = EnvFormDto.builder()
+                .envDto(envDto) // 게시글 본문 데이터 포함
+                .build();
 
-        // Then - 해당 게시글 ID로 이미지 리스트를 조회해서 검증
+        // When - 게시글 + 이미지 등록
+        envService.register(formDto, List.of(mockFile)); // 게시글과 이미지 파일을 함께 등록
+
+        Long envId = envDto.getEnvId(); // 등록된 게시글의 ID를 가져옴
+        assertNotNull(envId, "등록된 게시글 ID는 null이면 안 됩니다."); // 게시글 ID가 정상적으로 생성되었는지 확인 (null이면 실패)
+
+        // Then
+        // 해당 게시글 ID로 이미지 목록을 조회
         List<EnvImgDto> resultList = envImgService.getListByEnvId(envId);
-        assertEquals(1, resultList.size());
-        assertEquals("sample.jpg", resultList.get(0).getOriImgName());
-        assertEquals(envId, resultList.get(0).getEnvId());
-        log.info("등록된 이미지 정보: {}", resultList.get(0));
+
+        assertEquals(1, resultList.size(), "이미지는 1건 등록되어야 합니다."); // 이미지가 1건만 등록되었는지 검증
+        assertEquals("sample.jpg", resultList.get(0).getOriImgName()); // 등록된 이미지의 원본 파일명이 "sample.jpg"인지 확인
+        assertEquals(envId, resultList.get(0).getEnvId()); // 이미지가 등록된 게시글 ID와 일치하는지 확인
 
         log.info("등록된 이미지 정보: {}", resultList.get(0));
     }
+
 
     @Test
     @DisplayName("이미지 목록 조회 테스트")
     @Transactional
     public void testGetListByEnvId() throws Exception{
-        // Given - 1. 테스트용 게시글 등록
+        // Given - 1. 테스트용 게시글 DTO 준비
         EnvDto envDto = new EnvDto();
-        envDto.setMemberId(1L);
-        envDto.setTitle("이미지 목록 테스트 게시글");
-        envDto.setContent("여러 이미지를 등록합니다.");
-        envDto.setCategory("news");
-        envService.register(envDto);
+        envDto.setMemberId(1L); // 작성자 ID
+        envDto.setTitle("이미지 목록 테스트 게시글"); // 게시글 제목
+        envDto.setContent("여러 이미지를 등록합니다."); // 게시글 내용
+        envDto.setCategory("news"); // 게시글 카테고리
+
+        // 2. Mock 이미지 파일 2개 생성
+        MockMultipartFile file1 = new MockMultipartFile(
+                "imgFile", // 파라미터 이름
+                "img1.jpg", // 원본 파일명
+                "image/jpeg", // MIME 타입
+                "fake image content 1".getBytes()); // 파일 내용
+        MockMultipartFile file2 = new MockMultipartFile(
+                "imgFile",
+                "img2.jpg",
+                "image/jpeg",
+                "fake image content 2".getBytes());
+
+        //3. EnvFormDto로 게시글과 이미지 함께 등록 (게시글 정보를 EnvFormDto로 감싸서 이미지 파일과 함께 등록)
+        EnvFormDto formDto = EnvFormDto.builder()
+                .envDto(envDto) // 게시글 정보 포함
+                .build();
+
+        // When - 게시글 + 이미지 등록 요청
+        // EnvService를 통해 게시글과 이미지 2개를 DB 및 파일 시스템에 등록
+        envService.register(formDto, List.of(file1, file2)); // 이미지 포함 등록
+
+        // 등록된 게시글의 ID를 얻어서 null이 아닌지 검증
         Long envId = envDto.getEnvId();
-        assertNotNull(envId);
+        assertNotNull(envId, "게시글 ID는 null이 아니어야 함");
 
-        // Given - 2. 이미지 2건 등록
-        for (int i = 1; i <= 2; i++) {
-            EnvImgDto dto = EnvImgDto.builder().envId(envId).build();
-            MockMultipartFile mockFile = new MockMultipartFile(
-                    "imgFile",
-                    "img" + i + ".jpg",
-                    "image/jpeg",
-                    ("fake image content " + i).getBytes()
-            );
-            envImgService.register(dto, mockFile);
-        }
+        // 해당 게시글 ID로 이미지 목록 조회
+        List<EnvImgDto> imgList = envImgService.getListByEnvId(envId); // 이미지 서비스에서 게시글 ID에 해당하는 이미지 목록을 불러온다
 
-        // When - 이미지 목록 조회
-        List<EnvImgDto> imgList = envImgService.getListByEnvId(envId);
+        // Then - 이미지 2건이 조회되고 파일명이 정확해야 함
+        assertEquals(2, imgList.size(), "이미지 2건이 등록되어야 함"); // 총 2개 이미지여야 함
+        assertTrue(imgList.stream().anyMatch(img -> img.getOriImgName().equals("img1.jpg"))); // 이미지 목록 중 하나라도 oriImgName이 "img1.jpg"인지 확인
+        assertTrue(imgList.stream().anyMatch(img -> img.getOriImgName().equals("img2.jpg"))); // "img2.jpg"인지 확인
 
-        // Then - 이미지 2건이 조회되고, 파일명이 일치해야 함
-        assertEquals(2, imgList.size());
-        assertTrue(imgList.stream().anyMatch(img -> img.getOriImgName().equals("img1.jpg")));
-        assertTrue(imgList.stream().anyMatch(img -> img.getOriImgName().equals("img2.jpg")));
         log.info("조회된 이미지 목록: {}", imgList);
     }
 
@@ -122,36 +142,48 @@ class EnvImgServiceTest {
     @DisplayName("단일 이미지 삭제 테스트")
     @Transactional
     public void testDeleteById() throws Exception {
-        // Given - 1. 테스트용 게시글 등록
+        // Given - 1. 테스트용 게시글 + 이미지 등록
         EnvDto envDto = new EnvDto();
         envDto.setMemberId(1L);
         envDto.setTitle("삭제 테스트 게시글");
         envDto.setContent("삭제용 이미지 등록");
         envDto.setCategory("event");
-        envService.register(envDto);
-        Long envId = envDto.getEnvId();
-        assertNotNull(envId);
 
-        // Given - 2. 이미지 등록
-        EnvImgDto dto = EnvImgDto.builder().envId(envId).build();
+        // 2. 이미지 등록 - 테스트용 mock 이미지 파일 생성
         MockMultipartFile mockFile = new MockMultipartFile(
-                "imgFile", "delete.jpg", "image/jpeg", "fake delete image".getBytes()
+                "imgFile",
+                "delete.jpg",
+                "image/jpeg",
+                "fake delete image".getBytes()
         );
-        envImgService.register(dto, mockFile);
 
-        // 등록된 이미지 목록에서 ID 확인
-        List<EnvImgDto> imgList = envImgService.getListByEnvId(envId);
-        assertEquals(1, imgList.size());
-        Long envImgId = imgList.get(0).getEnvImgId();
+        // EnvFormDto 생성: 게시글 정보를 감싸는 DTO로 이미지와 함께 전달됨
+        EnvFormDto formDto = EnvFormDto.builder()
+                .envDto(envDto)
+                .build();
+
+        // EnvService를 통해 게시글과 이미지 등록 처리
+        envService.register(formDto, List.of(mockFile)); // 게시글 + 이미지 등록
+
+        // 등록된 게시글 ID 추출 및 null 확인
+        Long envId = envDto.getEnvId();
+        assertNotNull(envId, "게시글 ID는 null이 아니어야 합니다.");
+
+        // 3. 등록된 이미지 목록 조회 후 ID 추출
+        List<EnvImgDto> imgList = envImgService.getListByEnvId(envId); // 해당 게시글의 이미지 리스트 조회
+        assertEquals(1, imgList.size(), "이미지는 1건 등록되어야 합니다."); // 이미지 1건 존재 확인
+        Long envImgId = imgList.get(0).getEnvImgId(); // 삭제할 이미지의 ID 추출
 
         // When - 단일 이미지 삭제 수행
-        boolean deleted = envImgService.deleteById(envImgId);
+        boolean deleted = envImgService.deleteById(envImgId); // 이미지 삭제 실행
 
-        // Then - 삭제 성공 여부 확인 및 목록 비어 있는지 확인
-        assertTrue(deleted);
+        // Then - 삭제 성공 여부 확인
+        assertTrue(deleted, "이미지 삭제가 성공해야 합니다.");
 
+        // 삭제 후 다시 이미지 목록 조회 → 이미지가 0건인지 확인
         List<EnvImgDto> afterDeleteList = envImgService.getListByEnvId(envId);
-        assertEquals(0, afterDeleteList.size());
+        assertEquals(0, afterDeleteList.size(), "삭제 후 이미지 목록은 비어 있어야 합니다.");
+
         log.info("단일 이미지 삭제 성공. 이미지 ID: {}", envImgId);
     }
 
@@ -159,41 +191,114 @@ class EnvImgServiceTest {
     @DisplayName("게시글 ID로 이미지 전체 삭제 테스트")
     @Transactional
     public void testDeleteByEnvId() throws Exception{
-        // Given - 1. 테스트용 게시글 등록
+        // Given - 1. 테스트용 게시글 및 이미지 2개 등록
         EnvDto envDto = new EnvDto();
         envDto.setMemberId(1L);
         envDto.setTitle("전체 삭제 테스트 게시글");
         envDto.setContent("이미지 여러 개 등록 후 전체 삭제 테스트");
         envDto.setCategory("news");
-        envService.register(envDto);
+
+        // Mock 이미지 파일 2개 생성
+        List<MultipartFile> mockFiles = List.of(
+                new MockMultipartFile(
+                        "imgFile",
+                        "img1.jpg",
+                        "image/jpeg",
+                        "fake image content 1".getBytes()),
+                new MockMultipartFile(
+                        "imgFile",
+                        "img2.jpg",
+                        "image/jpeg",
+                        "fake image content 2".getBytes())
+        );
+
+        // 게시글과 이미지를 감싸는 EnvFormDto 생성
+        EnvFormDto formDto = EnvFormDto.builder()
+                .envDto(envDto)
+                .build();
+
+        // 게시글 + 이미지 등록 (서비스 호출)
+        envService.register(formDto, mockFiles);
+
+        // 등록된 게시글 ID 추출
+        Long envId = envDto.getEnvId();
+        assertNotNull(envId, "게시글 ID는 null이면 안 됩니다.");
+
+        // 등록된 이미지 목록 조회 (삭제 전 상태 확인)
+        List<EnvImgDto> beforeDeleteList = envImgService.getListByEnvId(envId);
+        assertEquals(2, beforeDeleteList.size(), "이미지는 2건 등록되어야 합니다."); // 이미지 수 확인
+
+        // When - 게시글 ID로 이미지 전체 삭제
+        int deletedCount = envImgService.deleteByEnvId(envId); // 게시글에 연결된 모든 이미지 삭제
+
+        // Then - 삭제된 개수 확인 및 최종 리스트 검증
+        assertEquals(2, deletedCount, "삭제된 이미지 개수는 2개여야 합니다."); // 반환된 삭제 수 확인
+
+        // 삭제 후 이미지 목록 다시 조회 → 비어 있어야 함
+        List<EnvImgDto> afterDeleteList = envImgService.getListByEnvId(envId);
+        assertTrue(afterDeleteList.isEmpty(), "삭제 후 이미지 목록은 비어 있어야 합니다.");
+
+        log.info("게시글 ID로 이미지 전체 삭제 성공. 삭제된 개수: {}", deletedCount);
+    }
+
+    @Test
+    @DisplayName("게시글 수정 시 이미지 하나만 삭제 테스트")
+    @Transactional
+    public void testModifyWithOneImageDeleted() throws Exception {
+        // Given - 게시글 + 이미지 2개 등록
+        EnvDto envDto = new EnvDto();
+        envDto.setMemberId(1L);
+        envDto.setTitle("수정 테스트 게시글");
+        envDto.setContent("이미지 2개 등록 후 하나 삭제 테스트");
+        envDto.setCategory("event");
+
+        // 테스트용 이미지 2개 생성
+        MockMultipartFile file1 = new MockMultipartFile("imgFile", "img1.jpg", "image/jpeg", "content1".getBytes());
+        MockMultipartFile file2 = new MockMultipartFile("imgFile", "img2.jpg", "image/jpeg", "content2".getBytes());
+
+        // 게시글 등록용 FormDto 생성
+        EnvFormDto registerDto = EnvFormDto.builder()
+                .envDto(envDto)
+                .build();
+
+        // 게시글 + 이미지 등록 실행
+        envService.register(registerDto, List.of(file1, file2));
+        // 등록된 게시글 ID 확인
         Long envId = envDto.getEnvId();
         assertNotNull(envId);
 
-        // Given - 2. 이미지 2개 등록
-        for (int i = 1; i <= 2; i++) {
-            EnvImgDto dto = EnvImgDto.builder().envId(envId).build();
-            MockMultipartFile mockFile = new MockMultipartFile(
-                    "imgFile",
-                    "img" + i + ".jpg",
-                    "image/jpeg",
-                    ("fake image content " + i).getBytes()
-            );
-            envImgService.register(dto, mockFile);
-        }
+        // 등록된 이미지 ID 목록 조회
+        List<EnvImgDto> beforeList = envImgService.getListByEnvId(envId);
+        assertEquals(2, beforeList.size());
 
-        // 등록된 이미지 수 검증
-        List<EnvImgDto> beforeDeleteList = envImgService.getListByEnvId(envId);
-        assertEquals(2, beforeDeleteList.size());
+        // 삭제할 이미지 ID를 선택 (여기서는 첫 번째 이미지)
+        Long deleteImgId = beforeList.get(0).getEnvImgId(); // 하나만 삭제
 
-        // When - 게시글 ID로 이미지 전체 삭제
-        int deletedCount = envImgService.deleteByEnvId(envId);
+        // When - 게시글 수정: 이미지 1개 삭제
+        // 수정용 게시글 정보 생성 (수정된 제목/내용)
+        EnvDto modifiedDto = EnvDto.builder()
+                .envId(envId) // 수정 대상 게시글 ID
+                .memberId(envDto.getMemberId()) // memberId는 수정 시에도 필요
+                .title("수정된 제목")
+                .content("수정된 내용")
+                .category("event")
+                .build();
 
-        // Then - 삭제된 개수 확인 및 최종 리스트 검증
-        assertEquals(2, deletedCount);
+        // 수정용 FormDto 생성 (삭제할 이미지 ID만 포함, 새로 추가할 이미지는 없음)
+        EnvFormDto modifyDto = EnvFormDto.builder()
+                .envDto(modifiedDto)
+                .deleteImgIds(List.of(deleteImgId)) // 삭제할 이미지 ID 전달
+                .build();
 
-        List<EnvImgDto> afterDeleteList = envImgService.getListByEnvId(envId);
-        assertTrue(afterDeleteList.isEmpty());
-        log.info("게시글 ID로 이미지 전체 삭제 성공. 삭제된 개수: {}", deletedCount);
+        // 게시글 수정 실행 (이미지 1개 삭제만 수행, 추가 이미지 없음)
+        envService.modify(modifyDto, List.of()); // 새로 추가된 이미지는 없음
+
+        // Then - 이미지 목록이 1개만 남아야 함
+        List<EnvImgDto> afterList = envImgService.getListByEnvId(envId); // 수정 후 이미지 목록 다시 조회
+        assertEquals(1, afterList.size(), "1개 이미지만 남아야 합니다."); // 이미지 수가 1개인지 검증
+        assertNotEquals(deleteImgId, afterList.get(0).getEnvImgId(), "삭제된 이미지 ID는 존재하지 않아야 합니다."); // 삭제한 이미지 ID가 목록에 남아있지 않은지 검증
+
+        log.info("수정 후 남은 이미지: {}", afterList.get(0));
     }
 
 }


### PR DESCRIPTION
[MemberController] 
일반 회원가입 시 provider 값이 null로 들어가 DB 제약조건 오류 발생 
→ provider='local', providerId=null 명시적으로 설정하여 해결

[EnvFormDto]
게시글 등록 및 수정 시, 이미지와 본문 데이터를 함께 처리하기 위한 폼 작성

[DB] env_img 테이블 수정
ALTER TABLE env_img
MODIFY COLUMN img_name VARCHAR(255) NULL,
MODIFY COLUMN img_url VARCHAR(500) NULL;

[EnvService]
이미지 포함 게시글 등록 및 수정 메서드로 변경 (EnvFormDto + MultipartFile)

[EnvServiceImpl]
이미지 포함 게시글 등록/수정 기능 추가 (EnvFormDto, MultipartFile 활용)
이미지까지 함께 삭제되도록 추가

[EnvImgServiceTest]
EnvFormDto 기반 게시글 + 이미지 등록 방식으로 테스트 전체 수정
게시글 수정 시 이미지 일부 삭제 테스트 추가

[[EnvServiceTest]]
EnvDto 단독 사용 → EnvFormDto 기반으로 수정
게시글 + 이미지 등록, 수정, 삭제 테스트 추가

[EnvApiController]
게시글 등록/수정 multipart/form-data 방식으로 전환 (EnvFormDto + 이미지 포함)
게시글 수정 시 BindingResult 제거 후 수동 유효성 검사 도입
게시글 삭제 시 컨트롤러는 그대로 유지 (서비스에서 이미지 함께 삭제 처리)

[EnvApiControllerTest]
게시글 등록/수정 multipart 구조 대응 테스트 및 이미지 교체 테스트 추가