### PR TITLE
[20250802] 환경톡톡 이미지 삭제 완료, 공지사항 수정화면까지 완료

### DIFF
--- a/DB 2차 정리.txt
+++ b/DB 2차 정리.txt
@@ -213,18 +213,20 @@ create table payment (
     foreign key(member_id) references member(member_id)
 );
 
+
 -- 환경톡톡 테이블 (env)
 CREATE TABLE env (
     env_id BIGINT AUTO_INCREMENT PRIMARY KEY,
     member_id BIGINT NOT NULL,
     title VARCHAR(255) NOT NULL,
-    content VARCHAR(1000) NOT NULL,
-    category VARCHAR(20) NOT NULL,
+    content VARCHAR(5000) NOT NULL,
     view_count INT NOT NULL DEFAULT 0,
+    category VARCHAR(20), 
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (member_id) REFERENCES member(member_id)
 );
+
 
 -- 환경톡톡 테이블 (env_img)
 CREATE TABLE env_img (
@@ -245,7 +247,8 @@ CREATE TABLE notice (
     title VARCHAR(255) NOT NULL,
     content VARCHAR(2000) NOT NULL,
     view_count INT NOT NULL DEFAULT 0,
+    category VARCHAR(20), 
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (member_id) REFERENCES member(member_id)
 );

--- a/ecovery/src/main/java/com/ecovery/controller/NoticeController.java
+++ b/ecovery/src/main/java/com/ecovery/controller/NoticeController.java
@@ -1,12 +1,16 @@
 package com.ecovery.controller;
 
+import com.ecovery.dto.EnvDto;
+import com.ecovery.dto.NoticeDto;
 import com.ecovery.service.MemberService;
 import com.ecovery.service.NoticeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /*
@@ -21,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
      - 250723 | yukyeong | 공지사항 목록 뷰 이동 메서드 작성 (GET /list)
      - 250723 | yukyeong | 게시글 등록 폼 이동 메서드 작성 (GET /register)
      - 250723 | yukyeong | 게시글 단건 조회 뷰 이동 메서드 작성 (GET /get)
+     - 250802 | yukyeong | 게시글 수정 폼 이동 메서드 작성 (GET /modify/{noticeId})
  */
 
 @Controller
@@ -52,5 +57,14 @@ public class NoticeController {
         return "notice/get"; // templates/notice/get.html 뷰 렌더링만
     }
 
+
+    // 수정 폼 이동
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    @GetMapping("/modify/{noticeId}")
+    public String modifyForm(@PathVariable Long noticeId, Model model) {
+        NoticeDto noticeDto = noticeService.get(noticeId);  // 단건 조회 서비스 호출
+        model.addAttribute("notice", noticeDto); // 모델에 전달
+        return "notice/modify"; // templates/notice/modify.html 로 이동
+    }
 
 }

--- a/ecovery/src/main/java/com/ecovery/domain/NoticeVO.java
+++ b/ecovery/src/main/java/com/ecovery/domain/NoticeVO.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
      - 250708 | yukyeong | VO 기본 필드 작성
      - 250723 | yukyeong | 작성자 닉네임(nickname) 필드 추가 (member 테이블 조인용)
      - 250729 | yukyeong | 카테고리 필드 추가
+     - 250802 | yukyeong | 작성자 권한(role) 필드 추가 (member 테이블 조인용)
  */
 
 @Getter @Setter
@@ -37,4 +38,5 @@ public class NoticeVO {
     private LocalDateTime updatedAt; // 수정일자
 
     private String nickname; // 작성자 닉네임 (조인된 member 테이블)
+    private String role; // 작성자 권한 (조인된 member 테이블)
 }

--- a/ecovery/src/main/java/com/ecovery/dto/NoticeDto.java
+++ b/ecovery/src/main/java/com/ecovery/dto/NoticeDto.java
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
  * @history
      - 250723 | yukyeong | 공지사항 게시글 DTO 클래스 최초 작성
      - 250729 | yukyeong | 카테고리 필드 추가
+     - 250802 | yukyeong | 작성자 권한(role) 필드 추가 (화면 표시용)
  */
 
 @Getter
@@ -42,4 +43,6 @@ public class NoticeDto {
     private int viewCount; // 조회수
     private LocalDateTime createdAt; // 등록일
     private LocalDateTime updatedAt; // 수정일
+
+    private String role; // 작성자 권한 (화면 표시용)
 }

--- a/ecovery/src/main/java/com/ecovery/service/NoticeServiceImpl.java
+++ b/ecovery/src/main/java/com/ecovery/service/NoticeServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
  * @history
      - 250723 | yukyeong | 공지사항 서비스 구현 클래스 전체 작성 (CRUD, 페이징, DTO 적용, 조회수 증가 포함)
      - 250729 | yukyeong | 게시글 category 필드 DTO/VO 매핑 처리 추가
+     - 250802 | yukyeong | VO → DTO 매핑 시 작성자 권한(role) 포함되도록 setRole 추가
  */
 
 @Service
@@ -55,6 +56,7 @@ public class NoticeServiceImpl implements NoticeService {
         noticeDto.setViewCount(notice.getViewCount());
         noticeDto.setCreatedAt(notice.getCreatedAt());
         noticeDto.setUpdatedAt(notice.getUpdatedAt());
+        noticeDto.setRole(notice.getRole()); // 작성자 권한 추가
         return noticeDto;
     }
 

--- a/ecovery/src/main/resources/mapper/NoticeMapper.xml
+++ b/ecovery/src/main/resources/mapper/NoticeMapper.xml
@@ -13,6 +13,8 @@
         - 250723 | yukyeong | 공지사항 목록, 단건 조회, 등록, 수정, 삭제 쿼리 작성
         - 250723 | yukyeong | 페이징 + 검색 목록 조회, 전체 개수 조회, 조회수 증가 쿼리 추가
         - 250729 | yukyeong | category 컬럼 관련 SELECT/INSERT/UPDATE 쿼리 반영 (검색 조건은 제외)
+        - 250802 | yukyeong | 카테고리 조건을 목록 조회(검색/페이징) 쿼리에 검색 조건으로 반영
+        - 250802 | yukyeong | 단건 조회(read) 쿼리에 작성자 권한(role) 컬럼 추가
 -->
 
 <mapper namespace="com.ecovery.mapper.NoticeMapper">
@@ -56,7 +58,8 @@
             n.view_count,
             n.created_at,
             n.updated_at,
-            m.nickname
+            m.nickname,
+            m.role
         FROM notice n
         JOIN member m ON n.member_id = m.member_id
         WHERE n.notice_id = #{noticeId}
@@ -115,37 +118,45 @@
 
 
     <!--
-        게시글 목록 조회 (페이징 + 검색) 쿼리
-        · 대상 테이블 : notice (게시글), member (작성자)
-        · 조인 방식 : INNER JOIN (notice.member_id = member.member_id)
+        게시글 목록 조회 (카테고리 + 페이징 + 검색) 쿼리
+        · 대상 테이블 : env (게시글), member (작성자)
+        · 조인 방식 : INNER JOIN (env.member_id = member.member_id)
         · 조회 컬럼 : 게시글 정보 + 작성자 닉네임
-        · 검색 조건 : type 값에 따라 다음 중 선택
-             - T   : 제목으로 검색
-             - C   : 내용으로 검색
-             - W   : 작성자 닉네임으로 검색
-             - TCW : 제목+내용+작성자 닉네임 모두 검색
-             - 그 외 : 제목+내용+작성자 닉네임 모두 검색
+        · 필터 조건:
+             - category: 게시글 카테고리(예: 환경 뉴스, 실천 인증 등)
+             - type: 검색 기준 (아래 중 하나)
+                 - T : 제목
+                 - C : 내용
+                 - W  : 작성자 닉네임
+                 - TCW : 제목 + 내용 + 닉네임
+                 - 기타 : 제목 + 내용 + 닉네임
+             - keyword : 실제 검색 키워드
         · 페이징 처리 : LIMIT #{amount} OFFSET #{offset}
-        · 용도 : 게시글 목록 화면 출력 + 검색 + 페이징
+        · 용도 : 게시글 목록 화면 출력 (카테고리 필터 + 검색 + 페이징)
     -->
 
     <!-- 검색 조건 SQL 분리 -->
     <sql id="criteria">
         <where>
+            <!-- 카테고리 조건 -->
+            <if test="category != null and category.trim() != ''">
+                AND n.category = #{category}
+            </if>
+
             <!-- keyword가 null이 아니고 공백이 아니면 조건문 실행 -->
             <if test="keyword != null and keyword.trim() != ''">
                 <choose>
                     <when test="'T'.equals(type)">
-                        n.title LIKE CONCAT('%', #{keyword}, '%')
+                        AND n.title LIKE CONCAT('%', #{keyword}, '%')
                     </when>
                     <when test="'C'.equals(type)">
-                        n.content LIKE CONCAT('%', #{keyword}, '%')
+                        AND n.content LIKE CONCAT('%', #{keyword}, '%')
                     </when>
                     <when test="'W'.equals(type)">
-                        m.nickname LIKE CONCAT('%', #{keyword}, '%')
+                        AND m.nickname LIKE CONCAT('%', #{keyword}, '%')
                     </when>
                     <when test="'TCW'.equals(type)">
-                        (
+                        AND (
                         n.title LIKE CONCAT('%', #{keyword}, '%')
                         OR n.content LIKE CONCAT('%', #{keyword}, '%')
                         OR m.nickname LIKE CONCAT('%', #{keyword}, '%')
@@ -153,7 +164,7 @@
                     </when>
                     <!-- 그 외의 경우도 제목/내용/작성자 모두 검색 -->
                     <otherwise>
-                        (
+                        AND (
                         n.title LIKE CONCAT('%', #{keyword}, '%')
                         OR n.content LIKE CONCAT('%', #{keyword}, '%')
                         OR m.nickname LIKE CONCAT('%', #{keyword}, '%')

--- a/ecovery/src/main/resources/static/css/eco-talk-detail.css
+++ b/ecovery/src/main/resources/static/css/eco-talk-detail.css
@@ -244,7 +244,7 @@ body {
 
 /* 메인 콘텐츠 영역 */
 .main-content {
-    padding: 60px 0 80px;
+    padding: 120px 0 80px;
     min-height: 100vh;
 }
 

--- a/ecovery/src/main/resources/static/css/notice-write-style.css
+++ b/ecovery/src/main/resources/static/css/notice-write-style.css
@@ -82,7 +82,7 @@
 /* 폼 섹션 컨테이너 */
 .form-section {
     margin-bottom: var(--form-section-gap);
-    padding: 30px 0;
+    padding: 10px 0;  /* 추가 : 기존 30px → 10px 으로 줄이기 */
     border-bottom: 1px solid var(--light-gray);
 }
 
@@ -108,7 +108,7 @@
 
 /* 폼 그룹 (기본 래퍼) */
 .form-group {
-    margin-bottom: 25px;
+    margin-bottom: 12px; /* 추가 : 기존 25px → 12px 등으로 줄이기 */
 }
 
 /* 폼 행 (여러 요소를 가로로 배치) */
@@ -116,6 +116,7 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 25px;
+    margin-bottom: 25px;  /* 추가 */
 }
 
 .form-group.half-width {

--- a/ecovery/src/main/resources/static/js/notice-get.js
+++ b/ecovery/src/main/resources/static/js/notice-get.js
@@ -14,6 +14,10 @@
  *                         - 수정일/작성일 구분 표시 기능 추가
  *                         - 관리자용 글 수정/삭제 버튼 처리 기능 추가
  *                         - 삭제 후 목록 이동 처리 추가
+     - 250802 | yukyeong | 작성자 정보 렌더링 개선:
+                            - roleMap 추가로 관리자/사용자 역할 표시
+                            - avatar 기본 이모지 설정
+                            - notice-role, notice-avatar 요소에 값 바인딩 추가
 
  */
 
@@ -53,11 +57,16 @@ document.addEventListener("DOMContentLoaded", function () {
 
             const views = new Intl.NumberFormat().format(data.viewCount) + '회';
 
+            const roleMap = {
+                "ADMIN": "관리자",
+                "USER": "사용자"
+            };
+
             // 게시글 정보 렌더링
             document.getElementById("notice-title").textContent = data.title;
             document.getElementById("notice-author").textContent = data.nickname ?? "알 수 없음";
             document.getElementById("notice-avatar").textContent = data.avatar ?? '👨‍💼';
-            document.getElementById("notice-role").textContent = data.role ?? "";
+            document.getElementById("notice-role").textContent = roleMap[data.role] ?? data.role ?? "";
             document.getElementById("notice-date").textContent = displayDate;
             document.getElementById("notice-views").textContent = views;
             document.getElementById("notice-content").innerHTML = data.content;

--- a/ecovery/src/main/resources/static/js/notice-modify.js
+++ b/ecovery/src/main/resources/static/js/notice-modify.js
@@ -1,0 +1,207 @@
+/**
+ * 공지사항 게시글 수정 스크립트
+ * 게시글 수정 페이지에서 에디터 초기화, 기존 데이터 바인딩, 유효성 검사, 미리보기 등
+ * 다양한 편집 인터랙션 기능을 제공함
+ *
+ * @author : yukyeong
+ * @fileName : notice-modify.js
+ * @since : 250802
+ * @history
+ *   - 250802 | yukyeong | 공지사항 수정 페이지 전용 스크립트 최초 작성:
+ *                        - Toast UI Editor 초기화 및 기존 content 바인딩
+ *                        - 카테고리 옵션 렌더링 및 기존 선택값 유지
+ *                        - 제목/내용 글자 수 실시간 카운트 기능 적용
+ *                        - 유효성 검사 및 PUT API 연동 처리
+ *                        - 미리보기 모달 구현 및 초기화 버튼 동작 추가
+ */
+
+document.addEventListener("DOMContentLoaded", function () {
+    window.onbeforeunload = null; // 제출 성공 시 호출하면 창 닫아도 경고 안뜸
+    localStorage.removeItem("draft"); // 임시글 제거
+
+    setupEditor(); // 에디터 초기화
+    loadCategories(); // 카테고리 옵션 추가
+    setupCharacterCounters(); // 글자 수 표시
+    setupFormSubmit(); // 유효성 검사 후 submit
+
+    // ✅ 미리보기 버튼 이벤트 바인딩
+    const previewBtn = document.getElementById("previewBtn");
+    if (previewBtn) {
+        previewBtn.addEventListener("click", previewPost);
+    }
+
+    // ✅ 초기화
+    const resetBtn = document.getElementById("resetBtn");
+    if (resetBtn) {
+        resetBtn.addEventListener("click", function () {
+            if (confirm("작성 중인 내용을 모두 초기화하시겠습니까?")) {
+                document.getElementById("modifyForm").reset();
+                editor.setHTML(initialContent || "");
+                document.getElementById("titleCounter").textContent = document.getElementById("title").value.length;
+                document.getElementById("contentCount").textContent = editor.getHTML().replace(/<[^>]*>/g, "").length;
+                document.getElementById("category").value = noticeCategory || "";
+            }
+        });
+    }
+});
+
+// ✅ Toast UI Editor 초기화 (수정용)
+function setupEditor() {
+    window.editor = new toastui.Editor({
+        el: document.querySelector('#editor'),
+        height: '500px',
+        initialEditType: 'wysiwyg',
+        previewStyle: 'vertical',
+        toolbarItems: [
+            ['heading', 'bold', 'italic', 'strike'],
+            ['ul', 'ol', 'hr'],
+            ['link'],
+            ['code', 'codeblock']
+        ]
+    });
+
+    // 초기 내용 세팅
+    if (window.initialContent) {
+        editor.setHTML(window.initialContent);
+    }
+}
+
+// ✅ 카테고리 옵션 렌더링 + 기존 선택값 유지
+function loadCategories() {
+    const categories = [
+        { id: "important", name: "중요 공지" },
+        { id: "service", name: "서비스" },
+        { id: "maintenance", name: "점검" },
+        { id: "event", name: "이벤트" },
+        { id: "general", name: "일반" }
+    ];
+
+    const select = document.getElementById("category");
+    categories.forEach(category => {
+        const option = document.createElement("option");
+        option.value = category.id;
+        option.textContent = category.name;
+        if (category.id === window.noticeCategory) {
+            option.selected = true;
+        }
+        select.appendChild(option);
+    });
+}
+
+// ✅ 글자 수 카운터
+function setupCharacterCounters() {
+    const titleInput = document.getElementById("title");
+    document.getElementById("titleCounter").textContent = titleInput.value.length;
+
+    titleInput.addEventListener("input", () => {
+        document.getElementById("titleCounter").textContent = titleInput.value.length;
+    });
+
+    document.getElementById("contentCount").textContent =
+        editor.getHTML().replace(/<[^>]*>/g, "").length;
+
+    editor.on("change", () => {
+        const contentLength = editor.getHTML().replace(/<[^>]*>/g, "").length;
+        document.getElementById("contentCount").textContent = contentLength;
+    });
+}
+
+// ✅ 유효성 검사
+function validateForm() {
+    let isValid = true;
+
+    const title = document.getElementById("title");
+    const contentHtml = editor.getHTML();
+    const contentText = contentHtml.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, '').trim();
+    const category = document.getElementById("category");
+
+    document.getElementById("titleError").textContent = "";
+    document.getElementById("contentError").textContent = "";
+    document.getElementById("categoryError").textContent = "";
+
+    if (title.value.trim() === "") {
+        document.getElementById("titleError").textContent = "제목을 입력해주세요.";
+        isValid = false;
+    }
+    if (contentText === "") {
+        document.getElementById("contentError").textContent = "내용을 입력해주세요.";
+        isValid = false;
+    }
+    if (!category.value) {
+        document.getElementById("categoryError").textContent = "카테고리를 선택해주세요.";
+        isValid = false;
+    }
+
+    return isValid;
+}
+
+// ✅ 폼 제출 이벤트 처리
+function setupFormSubmit() {
+    const form = document.getElementById("modifyForm");
+    form.addEventListener("submit", function (e) {
+        e.preventDefault();
+        document.getElementById("hiddenContent").value = editor.getHTML();
+        submitPost();
+    });
+}
+
+// ✅ 미리보기 모달
+function previewPost() {
+    const title = document.getElementById("title").value.trim();
+    const content = editor.getHTML();
+
+    if (!title || content.replace(/<[^>]*>/g, "").trim() === "") {
+        alert("미리보기를 위해 제목과 내용을 입력해주세요.");
+        return;
+    }
+
+    const previewHtml = `
+        <h2>${title}</h2>
+        ${content}
+    `;
+
+    document.getElementById("previewContent").innerHTML = previewHtml;
+    document.getElementById("previewModal").style.display = "block";
+}
+
+function closePreview() {
+    document.getElementById("previewModal").style.display = "none";
+}
+
+
+// ✅ 게시글 수정 처리
+function submitPost() {
+    if (!validateForm()) return;
+
+    const title = document.getElementById("title").value.trim();
+    const content = editor.getHTML();
+    const categoryId = document.getElementById("category").value;
+
+    window.onbeforeunload = null;
+
+    const noticeDto = {
+        title,
+        content,
+        category: categoryId
+    };
+
+    fetch(`/api/notice/modify/${window.noticeId}`, {
+        method: "PUT",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(noticeDto)
+    })
+        .then(response => {
+            if (!response.ok) throw new Error("수정 실패");
+            return response.json();
+        })
+        .then(data => {
+            alert("게시글이 성공적으로 수정되었습니다.");
+            window.location.href = "/notice/list";
+        })
+        .catch(error => {
+            console.error("수정 중 오류:", error);
+            alert("게시글 수정에 실패했습니다.");
+        });
+}

--- a/ecovery/src/main/resources/templates/env/get.html
+++ b/ecovery/src/main/resources/templates/env/get.html
@@ -10,6 +10,7 @@ GreenCycle 환경톡톡 게시글 상세보기
     - 250722 | yukyeong | 비동기 게시글 단건 조회 기능 적용
     - 250730 | yukyeong | 상세페이지 전체 구조 전면 수정 (레이아웃 개선, 관리자 버튼 정비 등)
     - 250731 | yukyeong | Toast UI Editor 기반 본문 표시로 전환, 첨부파일 관련 마크업 및 액션 버튼 주석 처리
+    - 250802 | yukyeong | 헤더와 페이지 헤더 간 간격 축소, 불필요한 <main> 태그 제거
 
 -->
 
@@ -30,7 +31,6 @@ GreenCycle 환경톡톡 게시글 상세보기
 <!-- 본문 콘텐츠 -->
 <div layout:fragment="content" class="fade-in">
     <!-- 메인 콘텐츠 영역 -->
-    <main class="main-content">
         <div class="container">
             <!-- 게시글 상세보기 헤더 섹션 (새로 추가) -->
             <section class="post-detail-hero">
@@ -160,7 +160,6 @@ GreenCycle 환경톡톡 게시글 상세보기
                 </div>
             </div>
         </div>
-    </main>
 </div>
 
 <th:block layout:fragment="script">

--- a/ecovery/src/main/resources/templates/env/modify.html
+++ b/ecovery/src/main/resources/templates/env/modify.html
@@ -13,7 +13,8 @@ GreenCycle 환경톡톡 게시글 수정 페이지
                           - 기존 파일첨부 UI 주석 처리 및 이미지 삽입은 addImageBlobHook 사용
                           - 카테고리, 제목, 본문 유효성 검사 설정 및 카운트 기능 연결
                           - env-modify.js 및 전역 설정 변수 연동 처리
-
+    - 250802 | yukyeong | 헤더와 페이지 헤더 간 간격 축소, 불필요한 <main> 태그 제거
+    - 250802 | yukyeong | 본문 글자 수 제한 2000자 → 5000자로 확장
 -->
 
 <!DOCTYPE html>
@@ -35,7 +36,6 @@ GreenCycle 환경톡톡 게시글 수정 페이지
 <!-- 본문 콘텐츠 -->
 <div layout:fragment="content" class="fade-in">
     <!-- Main Content -->
-    <main class="main-content">
         <div class="container">
             <!-- Page Header -->
             <section class="page-header fade-in">
@@ -75,7 +75,7 @@ GreenCycle 환경톡톡 게시글 수정 페이지
                             <input type="text" id="postTitle" name="title" class="form-input title-input"
                                    th:value="${env.title}"
                                    placeholder="제목을 입력하세요 (최대 255자)" maxlength="255" required>
-                            <div class="char-count"><span id="titleCount">0</span>/100</div>
+                            <div class="char-count"><span id="titleCount">0</span>/255</div>
                             <span class="error-message" id="titleError"></span>
                         </div>
 
@@ -87,7 +87,7 @@ GreenCycle 환경톡톡 게시글 수정 페이지
                             <!-- 실제 form 전송용 hidden input -->
                             <input type="hidden" name="content" id="hiddenContent" />
                             <!-- 글자 수 카운트 유지 -->
-                            <div class="char-count"><span id="contentCount">0</span>/2000</div>
+                            <div class="char-count"><span id="contentCount">0</span>/5000</div>
                             <span class="error-message" id="contentError"></span>
                         </div>
 
@@ -111,7 +111,7 @@ GreenCycle 환경톡톡 게시글 수정 페이지
 
                         <!-- Action Buttons -->
                         <div class="form-actions">
-                            <button type="button" class="btn btn-outline" onclick="previewPost()">👁️ 미리보기</button>
+                            <button type="button" class="btn btn-outline" onclick="previewPost()">📄 미리보기</button>
                             <button type="button" class="btn btn-danger" onclick="location.href='/env/list'">❌ 취소</button>
                             <button type="button" class="btn btn-primary" onclick="submitModifiedPost()">📝 수정하기</button>
                         </div>
@@ -145,7 +145,6 @@ GreenCycle 환경톡톡 게시글 수정 페이지
 
             </div>
         </div>
-    </main>
 
     <!-- Preview Modal -->
     <div class="modal-overlay" id="previewModal" style="display: none;">
@@ -212,7 +211,7 @@ GreenCycle 환경톡톡 게시글 수정 페이지
 
         // 에디터 설정
         var editorConfig = {
-            maxLength: 2000,
+            maxLength: 5000,
             allowedTags: ['b', 'i', 'u', 'ul', 'ol', 'li', 'a'],
             emojiCategories: {
                 nature: ['🌱', '🌳', '🌍', '🌿', '🌱', '🍃', '🌾', '🌸'],
@@ -231,8 +230,8 @@ GreenCycle 환경톡톡 게시글 수정 페이지
             },
             content: {
                 required: true,
-                maxLength: 2000,
-                message: '내용을 입력해주세요 (최대 2000자)'
+                maxLength: 5000,
+                message: '내용을 입력해주세요 (최대 5000자)'
             },
             category: {
                 required: true,

--- a/ecovery/src/main/resources/templates/env/register.html
+++ b/ecovery/src/main/resources/templates/env/register.html
@@ -18,6 +18,8 @@ GreenCycle 환경톡톡 게시글 등록 페이지
                           - addImageBlobHook으로 이미지 본문 자동 삽입 처리
                           - 작성 내용은 hiddenContent에 저장 후 전송
                           - 기존 파일 첨부 영역 UI는 주석 처리됨
+    - 250802 | yukyeong | 헤더와 페이지 헤더 간 간격 축소, 불필요한 <main> 태그 제거
+    - 250802 | yukyeong | 본문 글자 수 제한 2000자 → 5000자로 확장
 -->
 
 <!DOCTYPE html>
@@ -39,7 +41,6 @@ GreenCycle 환경톡톡 게시글 등록 페이지
 <!-- 본문 콘텐츠 -->
 <div layout:fragment="content" class="fade-in">
     <!-- Main Content -->
-    <main class="main-content">
         <div class="container">
             <!-- Page Header -->
             <section class="page-header fade-in">
@@ -91,7 +92,7 @@ GreenCycle 환경톡톡 게시글 등록 페이지
                             <!-- 실제 form 전송용 hidden input -->
                             <input type="hidden" name="content" id="hiddenContent" />
                             <!-- 글자 수 카운트 유지 -->
-                            <div class="char-count"><span id="contentCount">0</span>/2000</div>
+                            <div class="char-count"><span id="contentCount">0</span>/5000</div>
                             <span class="error-message" id="contentError"></span>
                         </div>
 
@@ -115,9 +116,9 @@ GreenCycle 환경톡톡 게시글 등록 페이지
 
                         <!-- Action Buttons -->
                         <div class="form-actions">
-                            <button type="button" class="btn btn-outline" onclick="previewPost()">👁️ 미리보기</button>
+                            <button type="button" class="btn btn-outline" onclick="previewPost()">📄 미리보기</button>
                             <button type="button" class="btn btn-danger" onclick="location.href='/env/list'">❌ 취소</button>
-                            <button type="submit" class="btn btn-primary">📝 게시하기</button>
+                            <button type="submit" class="btn btn-primary">📝 등록하기</button>
                         </div>
 
 
@@ -149,7 +150,6 @@ GreenCycle 환경톡톡 게시글 등록 페이지
 
             </div>
         </div>
-    </main>
 
     <!-- Preview Modal -->
     <div class="modal-overlay" id="previewModal" style="display: none;">
@@ -163,7 +163,7 @@ GreenCycle 환경톡톡 게시글 등록 페이지
             </div>
             <div class="modal-footer">
                 <button class="btn btn-secondary" onclick="closePreview()">닫기</button>
-                <button class="btn btn-primary" onclick="submitPost()">게시하기</button>
+                <button class="btn btn-primary" onclick="submitPost()">등록하기</button>
             </div>
         </div>
     </div>
@@ -208,7 +208,7 @@ GreenCycle 환경톡톡 게시글 등록 페이지
 
             // 에디터 설정
             var editorConfig = {
-                maxLength: 2000,
+                maxLength: 5000,
                 allowedTags: ['b', 'i', 'u', 'ul', 'ol', 'li', 'a'],
                 emojiCategories: {
                     nature: ['🌱', '🌳', '🌍', '🌿', '🌱', '🍃', '🌾', '🌸'],
@@ -227,8 +227,8 @@ GreenCycle 환경톡톡 게시글 등록 페이지
                 },
                 content: {
                     required: true,
-                    maxLength: 2000,
-                    message: '내용을 입력해주세요 (최대 2000자)'
+                    maxLength: 5000,
+                    message: '내용을 입력해주세요 (최대 5000자)'
                 },
                 categoryId: {
                     required: true,

--- a/ecovery/src/main/resources/templates/notice/get.html
+++ b/ecovery/src/main/resources/templates/notice/get.html
@@ -14,6 +14,8 @@ GreenCycle 환경톡톡 게시글 상세보기
                           - notice-detail-layout, notice-article 등 구조 정비
                           - 관리자 전용 버튼 섹션(admin-actions) 개선
                           - 공지사항 조회 전용 notice-get.js 연동
+    - 250802 | yukyeong | 작성자 정보(author-info) 영역 구조 개선 : 아바타, 작성자명, 권한(role) 요소 분리 및 ID 지정
+    - 250802 | yukyeong | 관리자 전용 영역 제목(admin-actions-title) 블록 추가
 -->
 
 <!DOCTYPE html>
@@ -22,8 +24,8 @@ GreenCycle 환경톡톡 게시글 상세보기
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layouts/layout1}">
 
-<head th:with="pageTitle='환경톡톡 - 게시글 조회'">
-    <title>환경톡톡</title>
+<head th:with="pageTitle='공지사항 - 게시글 조회'">
+    <title>공지사항</title>
     <th:block layout:fragment="css">
         <link rel="stylesheet" th:href="@{/css/notice-detail.css}">
     </th:block>
@@ -74,9 +76,9 @@ GreenCycle 환경톡톡 게시글 상세보기
                         <!-- 공지사항 메타 정보 -->
                         <div class="notice-article-meta">
                             <div class="author-info">
-                                <span class="author-avatar" id="notice-avatar">👨‍💼</span>
-                                <div class="author-name" id="notice-author">운영팀</div>
-                                <div class="author-role" id="notice-role">관리자</div>
+                                <span class="author-avatar" id="notice-avatar"></span>
+                                <div class="author-name" id="notice-author"></div>
+                                <div class="author-role" id="notice-role"></div>
                             </div>
                             <div class="notice-info">
                                 <div class="notice-date">
@@ -104,6 +106,9 @@ GreenCycle 환경톡톡 게시글 상세보기
 
                 <!-- 관리자 전용 액션 버튼들 (관리자만) -->
                 <section class="admin-actions" sec:authorize="hasAnyAuthority('ROLE_ADMIN')">
+                    <div class="admin-actions-title">
+                        <span>🛠️ 관리자 전용</span>
+                    </div>
                     <div class="admin-action-buttons">
                         <a id="editBtn" class="admin-btn edit-btn">
                             ✏️ 글 수정

--- a/ecovery/src/main/resources/templates/notice/list.html
+++ b/ecovery/src/main/resources/templates/notice/list.html
@@ -36,7 +36,7 @@ Thymeleaf layout:decorate="~{layouts/layout1}"로 레이아웃을 구성하며,
             <section class="page-header fade-in">
                 <div class="page-header-content">
                     <h1>📢 공지사항</h1>
-                    <p>GreenCycle의 새로운 소식과 중요한 안내사항을 확인하세요</p>
+                    <p>Ecovery의 새로운 소식과 중요한 안내사항을 확인하세요</p>
 
                     <!-- 공지사항 통계 - 서버에서 통계 데이터 제공 -->
 <!--                    <div class="page-stats">-->

--- a/ecovery/src/main/resources/templates/notice/modify.html
+++ b/ecovery/src/main/resources/templates/notice/modify.html
@@ -1,91 +1,245 @@
 <!--
-환경톡톡 게시글 수정 화면
-기존 데이터를 수정할 수 있도록 입력폼에 출력
-@author : yukyeong
+공지사항 수정 페이지
+운영자가 기존 공지사항 내용을 수정할 수 있는 입력 폼 제공
+Toast UI Editor 기반 본문 수정, 카테고리/제목 수정, 미리보기, 통계 및 작성 가이드 사이드바 포함
+@author : eunji
 @fileName : modify.html
-@since : 250717
+@since : 250721
+@history
+    - 250721 | yukyeong | 단순 테스트용 글쓰기 폼 임시 작성
+    - 250802 | yukyeong | 공지사항 수정 페이지로 리팩토링:
+                          - 기존 글 정보 바인딩(title, category, content)
+                          - notice-modify.js 및 초기 데이터 세팅 로직 반영
+                          - submit 버튼 텍스트 및 모달 라벨 수정
+                          - <main> 태그 제거 및 레이아웃 간격 조정
 -->
 
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-    <meta charset="UTF-8">
-    <title>환경톡톡 게시글 수정</title>
-    <style>
-        body {
-            font-family: sans-serif;
-            padding: 40px;
-            display: flex;
-            justify-content: center;
-        }
-        .form-container {
-            width: 600px;
-        }
-        label {
-            display: block;
-            font-weight: bold;
-            margin-top: 20px;
-        }
-        input[type="text"],
-        textarea {
-            width: 100%;
-            padding: 10px;
-            margin-top: 5px;
-        }
-        .button-group {
-            margin-top: 20px;
-            text-align: right;
-        }
-        button {
-            padding: 8px 16px;
-            margin-left: 10px;
-        }
-    </style>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/layout1}">
+
+<head th:with="pageTitle='공지사항 - 수정하기'">
+    <title>공지사항</title>
+    <th:block layout:fragment="css">
+        <!-- Toast UI Editor 스타일 CDN 추가 -->
+        <link rel="stylesheet" href="https://uicdn.toast.com/editor/latest/toastui-editor.min.css" />
+        <link rel="stylesheet" th:href="@{/css/notice-style.css}">
+        <link rel="stylesheet" th:href="@{/css/notice-write-style.css}">
+    </th:block>
 </head>
+
 <body>
-<div class="form-container">
-    <h2>환경톡톡 게시글 수정</h2>
+<!-- 본문 콘텐츠 -->
+<div layout:fragment="content" class="fade-in">
+    <!-- 메인 콘텐츠 영역 -->
+        <div class="container">
+            <!-- 페이지 헤더 -->
+            <section class="page-header fade-in">
+                <div class="page-header-content">
+                    <h1>✍️ 공지사항 수정하기</h1>
+                    <p>Ecovery 사용자들에게 전달할 중요한 소식을 수정하세요</p>
+                </div>
+            </section>
 
-    <form th:action="@{/env/modify}" method="post">
-        <!-- 게시글 ID -->
-        <input type="hidden" name="envId" th:value="${env.envId}" />
+            <!-- 공지사항 작성 폼 컨테이너 -->
+            <div class="write-container fade-in">
+                <!-- 작성 폼 메인 영역 -->
+                <div class="write-main">
+                    <!-- 타임리프 폼 태그 시작 -->
+                    <form id="modifyForm" class="write-form" enctype="multipart/form-data">
 
-        <!-- Criteria 정보 hidden -->
-        <input type="hidden" name="pageNum" th:value="${cri.pageNum}" />
-        <input type="hidden" name="amount" th:value="${cri.amount}" />
-        <input type="hidden" name="type" th:value="${cri.type}" />
-        <input type="hidden" name="keyword" th:value="${cri.keyword}" />
+                        <!-- 폼 헤더 -->
+                        <div class="form-header">
+                            <h2>📝 공지사항 수정하기</h2>
+                            <div class="form-actions-top">
+                                <!-- 미리보기 버튼 -->
+                                <button type="button" class="btn btn-secondary" id="previewBtn">
+                                    📄 미리보기
+                                </button>
+                            </div>
+                        </div>
 
-        <label for="title">제목</label>
-        <input type="text" id="title" name="title" th:value="${env.title}" required />
+                        <!-- 기본 정보 섹션 -->
 
-        <label for="memberId">작성자 ID</label>
-        <input type="text" id="memberId" name="memberId" th:value="${env.memberId}" readonly />
+                        <!-- 카테고리 및 중요도 설정 -->
+                        <div class="form-row">
+                            <!-- 카테고리 선택 -->
+                            <div class="form-group half-width">
+                                <label for="category" class="form-label required">
+                                    🏷️ 카테고리
+                                </label>
+                                <select id="category" name="category" class="form-select" required>
+                                    <option value="">카테고리를 선택하세요</option>
+                                    <!-- JS로 동적 렌더링 -->
+                                </select>
+                                <span class="error-message" id="categoryError"></span>
+                            </div>
+                        </div>
 
-        <label for="content">상세설명</label>
-        <textarea id="content" name="content" rows="8" required
-                  th:text="${env.content}"></textarea>
+                        <!-- 제목 입력 -->
+                        <div class="form-group">
+                            <label for="title" class="form-label required">📌 제목</label>
+                            <input type="text" id="title" name="title" class="form-input"
+                                   th:value="${notice.title}"
+                                   placeholder="공지사항 제목을 입력하세요" required maxlength="255">
+                            <div class="char-counter">
+                                <span id="titleCounter">0</span>/255
+                            </div>
+                            <span class="error-message" id="titleError"></span>
+                        </div>
 
-        <div class="button-group">
-            <button type="submit">수정하기</button>
+
+                        <!-- 내용 작성 섹션 -->
+                        <div class="form-section">
+                            <label class="form-label" for="editor">📝 내용 작성</label>
+                            <!-- Toast UI Editor가 들어갈 영역 (기존 클래스 유지) -->
+                            <div id="editor" class="form-textarea content-editor"></div>
+                            <!-- 실제 form 전송용 hidden input -->
+                            <input type="hidden" name="content" id="hiddenContent" />
+                            <!-- 글자 수 카운트 유지 -->
+                            <div class="char-count"><span id="contentCount">0</span>/2000</div>
+                            <span class="error-message" id="contentError"></span>
+                        </div>
+
+
+                        <!-- 폼 하단 액션 버튼들 -->
+                        <div class="form-actions">
+                            <div class="action-left">
+                                <a onclick="location.href='/notice/list'" class="btn btn-outline">
+                                    ← 목록으로
+                                </a>
+                            </div>
+                            <div class="action-right">
+                                <button type="button" class="btn btn-secondary" id="resetBtn">
+                                    🔄 초기화
+                                </button>
+                                <button type="submit" name="action" value="publish" class="btn btn-primary" id="publishBtn">
+                                    📢 수정하기
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+
+                <!-- 사이드바 -->
+                <div class="write-sidebar fade-in">
+                    <!-- 작성 가이드 -->
+                    <div class="sidebar-card">
+                        <h3>📖 작성 가이드</h3>
+                        <div class="guide-content">
+                            <div class="guide-item">
+                                <strong>📌 제목 작성 팁</strong>
+                                <p>명확하고 간결한 제목을 작성하세요. 이모지를 활용하면 더욱 눈에 띕니다.</p>
+                            </div>
+                            <div class="guide-item">
+                                <strong>📝 내용 작성 팁</strong>
+                                <p>중요한 내용은 굵게 표시하고, 목록을 활용하여 가독성을 높이세요.</p>
+                            </div>
+                        </div>
+                    </div>
+
+
+                    <!-- 통계 정보 -->
+                    <div class="sidebar-card">
+                        <h3>📊 통계 정보</h3>
+                        <div class="stats-grid">
+                            <div class="stat-item">
+                                <span class="stat-number">128</span>
+                                <span class="stat-label">전체 공지</span>
+                            </div>
+                            <div class="stat-item">
+                                <span class="stat-number">3</span>
+                                <span class="stat-label">오늘 발행</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- 빠른 액션 -->
+                    <div class="sidebar-card">
+                        <h3>⚡ 빠른 액션</h3>
+                        <div class="quick-actions">
+                            <a href="#" class="quick-btn">
+                                📋 공지 관리
+                            </a>
+                            <a href="#" class="quick-btn">
+                                📈 통계 보기
+                            </a>
+                            <a href="#" class="quick-btn">
+                                ⚙️ 설정
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
-    </form>
 
-    <!-- 삭제 form (분리된 form) -->
-    <form th:action="@{/env/remove}" method="post" style="display:inline;">
-        <input type="hidden" name="envId" th:value="${env.envId}" />
-        <input type="hidden" name="pageNum" th:value="${cri.pageNum}" />
-        <input type="hidden" name="amount" th:value="${cri.amount}" />
-        <input type="hidden" name="type" th:value="${cri.type}" />
-        <input type="hidden" name="keyword" th:value="${cri.keyword}" />
-        <button type="submit">삭제</button>
-    </form>
+    <!-- Preview Modal -->
+    <div class="modal-overlay" id="previewModal" style="display: none;">
+        <div class="modal-content preview-modal">
+            <div class="modal-header">
+                <h3>📄 미리보기</h3>
+                <button class="modal-close" onclick="closePreview()">×</button>
+            </div>
+            <div class="modal-body" id="previewContent">
+                <!-- Preview content will be inserted here -->
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-secondary" onclick="closePreview()">닫기</button>
+                <button class="btn btn-primary" onclick="submitPost()">수정하기</button>
+            </div>
+        </div>
+    </div>
 
-    <!-- 목록 이동 버튼 -->
-    <a th:href="@{/env/list(pageNum=${cri.pageNum}, amount=${cri.amount}, type=${cri.type}, keyword=${cri.keyword})}">
-        <button type="button">목록으로</button>
-    </a>
 
 </div>
+<th:block layout:fragment="script">
+    <script th:src="@{/js/notice-write-script.js}"></script>
+    <script th:src="@{/js/notice-modify.js}"></script>
+
+    <!-- Toast UI Editor JS CDN 추가 -->
+    <script src="https://uicdn.toast.com/editor/latest/toastui-editor-all.min.js"></script>
+
+
+    <!-- 타임리프 변수 및 에디터 설정 -->
+    <script th:inline="javascript">
+        const noticeId = /*[[${notice.noticeId}]]*/ 0;
+        const noticeCategory = /*[[${notice.category}]]*/ null;
+        const initialContent = /*[[${notice.content}]]*/ "";
+
+        window.noticeId = noticeId;
+        window.noticeCategory = noticeCategory;
+        window.initialContent = initialContent;
+
+        var maxFileSize = /*[[${maxFileSize}]]*/ 10485760; // 10MB
+        var maxFileCount = /*[[${maxFileCount}]]*/ 5;
+
+        // 폼 검증 규칙
+        var validationRules = {
+            title: {
+                required: true,
+                maxLength: 255,
+                message: '제목을 입력해주세요 (최대 255자)'
+            },
+            content: {
+                required: true,
+                maxLength: 2000,
+                message: '내용을 입력해주세요 (최대 2000자)'
+            },
+            categoryId: {
+                required: true,
+                message: '카테고리를 선택해주세요'
+            }
+        };
+
+
+        // form 제출 전 에디터 값 설정
+        function beforeSubmit() {
+            document.getElementById("hiddenContent").value = editor.getHTML();
+            document.getElementById("modifyForm").submit();
+        }
+    </script>
+</th:block>
 </body>
 </html>

--- a/ecovery/src/main/resources/templates/notice/register.html
+++ b/ecovery/src/main/resources/templates/notice/register.html
@@ -1,7 +1,7 @@
 <!--
-GreenCycle 환경톡톡 게시글 등록 페이지
-환경 관련 게시글을 작성할 수 있는 입력 폼, 에디터, 이미지 업로드, 이모지, 미리보기 등의 기능 제공
-사용자 정보 및 작성 통계는 사이드바에 표시됨
+공지사항 등록 페이지
+사이트 운영팀이 사용자에게 전달할 중요 공지를 작성할 수 있는 입력 폼 제공
+Toast UI Editor 기반 본문 작성, 카테고리 선택, 미리보기, 통계 및 가이드 사이드바 포함
 @author : eunji
 @fileName : register.html
 @since : 250721
@@ -13,6 +13,7 @@ GreenCycle 환경톡톡 게시글 등록 페이지
                           - 미리보기 모달 및 발행 버튼 동작 추가
                           - 작성 가이드, 통계 정보, 빠른 액션 포함 사이드바 구성
                           - notice-write-script.js, notice-register.js 연동
+    - 250802 | yukyeong | 헤더와 페이지 헤더 간 간격 축소, 불필요한 <main> 태그 제거
 -->
 
 <!DOCTYPE html>
@@ -35,7 +36,6 @@ GreenCycle 환경톡톡 게시글 등록 페이지
 <!-- 본문 콘텐츠 -->
 <div layout:fragment="content" class="fade-in">
     <!-- 메인 콘텐츠 영역 -->
-    <main class="main-content">
         <div class="container">
             <!-- 페이지 헤더 -->
             <section class="page-header fade-in">
@@ -59,41 +59,39 @@ GreenCycle 환경톡톡 게시글 등록 페이지
                             <div class="form-actions-top">
                                 <!-- 미리보기 버튼 -->
                                 <button type="button" class="btn btn-secondary" id="previewBtn">
-                                    👁️ 미리보기
+                                    📄 미리보기
                                 </button>
                             </div>
                         </div>
 
                         <!-- 기본 정보 섹션 -->
-                        <div class="form-section">
-                            <h3>📋 기본 정보</h3>
 
-                            <!-- 제목 입력 -->
-                            <div class="form-group">
-                                <label for="title" class="form-label required">📌 제목</label>
-                                <input type="text" id="title" name="title" class="form-input"
-                                       placeholder="공지사항 제목을 입력하세요" required maxlength="100">
-                                <div class="char-counter">
-                                    <span id="titleCounter">0</span>/255
-                                </div>
-                                <span class="error-message" id="titleError"></span>
-                            </div>
-
-                            <!-- 카테고리 및 중요도 설정 -->
-                            <div class="form-row">
-                                <!-- 카테고리 선택 -->
-                                <div class="form-group half-width">
-                                    <label for="category" class="form-label required">
-                                        🏷️ 카테고리
-                                    </label>
-                                    <select id="category" name="category" class="form-select" required>
-                                        <option value="">카테고리를 선택하세요</option>
-                                        <!-- JS로 동적 렌더링 -->
-                                    </select>
-                                    <span class="error-message" id="categoryError"></span>
-                                </div>
+                        <!-- 카테고리 및 중요도 설정 -->
+                        <div class="form-row">
+                            <!-- 카테고리 선택 -->
+                            <div class="form-group half-width">
+                                <label for="category" class="form-label required">
+                                    🏷️ 카테고리
+                                </label>
+                                <select id="category" name="category" class="form-select" required>
+                                    <option value="">카테고리를 선택하세요</option>
+                                    <!-- JS로 동적 렌더링 -->
+                                </select>
+                                <span class="error-message" id="categoryError"></span>
                             </div>
                         </div>
+
+                        <!-- 제목 입력 -->
+                        <div class="form-group">
+                            <label for="title" class="form-label required">📌 제목</label>
+                            <input type="text" id="title" name="title" class="form-input"
+                                   placeholder="공지사항 제목을 입력하세요" required maxlength="255">
+                            <div class="char-counter">
+                                <span id="titleCounter">0</span>/255
+                            </div>
+                            <span class="error-message" id="titleError"></span>
+                        </div>
+
 
                         <!-- 내용 작성 섹션 -->
                         <div class="form-section">
@@ -120,7 +118,7 @@ GreenCycle 환경톡톡 게시글 등록 페이지
                                     🔄 초기화
                                 </button>
                                 <button type="submit" name="action" value="publish" class="btn btn-primary" id="publishBtn">
-                                    📢 발행하기
+                                    📢 등록하기
                                 </button>
                             </div>
                         </div>
@@ -178,7 +176,6 @@ GreenCycle 환경톡톡 게시글 등록 페이지
                 </div>
             </div>
         </div>
-    </main>
 
     <!-- Preview Modal -->
     <div class="modal-overlay" id="previewModal" style="display: none;">
@@ -192,7 +189,7 @@ GreenCycle 환경톡톡 게시글 등록 페이지
             </div>
             <div class="modal-footer">
                 <button class="btn btn-secondary" onclick="closePreview()">닫기</button>
-                <button class="btn btn-primary" onclick="submitPost()">이대로 발행</button>
+                <button class="btn btn-primary" onclick="submitPost()">등록하기</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
어제 DB에 삭제된 이미지가 폴더에서 삭제가 안되는 오류 발생
[application.yml] 파일 경로 수정

1. 공지사항 등록하기 화면 수정

카테고리 선택 부분과 제목 입력 사이의 간격을 늘리기
[notice-write-style.css] form-row에 margin-bottom 추가함

공지사항 제목 입력 필드와 내용 작성 영역 사이의 간격 줄이기
[notice-write-style.css] 
form-group에 margin-bottom 12로 수정
form-section에 padding 30px → 10px 으로 줄이기

공지사항 등록하기 헤더 부분과 헤더 섹션 사이 간격 줄이기
[register.html] 헤더와 페이지 헤더 간 간격 축소, 불필요한 <main> 태그 제거

----------------------------------------------------------------

2. 공지사항 수정화면 만들기
notice/
[modity.html]
공지사항 수정 페이지로 리팩토링:
- 기존 글 정보 바인딩(title, category, content)
- notice-modify.js 및 초기 데이터 세팅 로직 반영
- submit 버튼 텍스트 및 모달 라벨 수정
- <main> 태그 제거 및 레이아웃 간격 조정

[notice-modify.js]
공지사항 수정 페이지 전용 스크립트 최초 작성:
- Toast UI Editor 초기화 및 기존 content 바인딩
- 카테고리 옵션 렌더링 및 기존 선택값 유지
- 제목/내용 글자 수 실시간 카운트 기능 적용
- 유효성 검사 및 PUT API 연동 처리
- 미리보기 모달 구현 및 초기화 버튼 동작 추가

공지사항 수정화면으로 이동하는 폼이 컨트롤러에 없어서 추가함
[NoticeController] 게시글 수정 폼 이동 메서드 작성 (GET /modify/{noticeId})

----------------------------------------------------------------

3. 환경톡톡 상세보기 화면에서 헤더 부분과 헤더 섹션 사이 간격이 너무 넓은거 수정함
[get.html] 헤더와 페이지 헤더 간 간격 축소, 불필요한 <main> 태그 제거

----------------------------------------------------------------

4. 환경톡톡 등록, 수정 화면에서 헤더 부분과 헤더 섹션 사이 간격이 너무 넓은거 수정함
[register.html] 불필요한 <main> 태그 제거
[modify.html] 불필요한 <main> 태그 제거

----------------------------------------------------------------

5. 공지사항 등록, 수정 화면에서 헤더 부분과 헤더 섹션 사이 간격이 너무 넓은거 수정함
[modify.html] 불필요한 <main> 태그 제거

----------------------------------------------------------------

6. 공지사항 상세보기 화면에서 작성자 아래에 권한이 안나오는 현상
[NoticeVO] 작성자 권한(role) 필드 추가 (member 테이블 조인용)
[NoticeDto] 작성자 권한(role) 필드 추가 (화면 표시용)
[NoticeMapper.xml] 단건 조회(read) 쿼리에 작성자 권한(role) 컬럼 추가
[NoticeServiceImpl] VO → DTO 매핑 시 작성자 권한(role) 포함되도록 setRole 추가
[get.html]
작성자 정보(author-info) 영역 구조 개선 : 아바타, 작성자명, 권한(role) 요소 분리 및 ID 지정
[notice-get.js]
작성자 정보 렌더링 개선:
- roleMap 추가로 관리자/사용자 역할 표시
- avatar 기본 이모지 설정
- notice-role, notice-avatar 요소에 값 바인딩 추가

----------------------------------------------------------------

7. 공지사항 상세보기 페이지 게시글 수정버튼 부분에 관리자 전용 이라는 말 추가하기
[get.html] 관리자 전용 영역 제목(admin-actions-title) 블록 추가

----------------------------------------------------------------

8. 공지사항 목록에서 카테고리 연결
[NoticeMapepr.xml] 카테고리 조건을 목록 조회(검색/페이징) 쿼리에 검색 조건으로 반영

----------------------------------------------------------------

9. 환경톡톡 게시판 내용부분 글자수 2000 → 5000으로 변경
[DB]
ALTER TABLE env
MODIFY content VARCHAR(5000) NOT NULL;

[register.html] 본문 글자 수 제한 2000자 → 5000자로 확장
[modify.html] 본문 글자 수 제한 2000자 → 5000자로 확장

----------------------------------------------------------------

10. 환경톡톡 게시판에서 게시글 삭제할때, 이미지도 같이 DB와 폴더에서 삭제되는지 확인하기
DB에는 삭제가 되는데 폴더에서는 삭제가 안되서 아래 코드 수정함
[EnvServiceImpl] 
 remove() 게시글 삭제 로직 개선:
- 본문 이미지 URL과 첨부 이미지(imgName) 구분하여 각각 삭제
- 본문 이미지는 imgUrl 기준, 첨부 이미지는 envId 기준으로 삭제


이제 사진이 하나인 게시글을 삭제하면 폴더에 있는 사진까지 잘 삭제가 되는데, 
사진이 여러개 있는 게시글을 삭제하면 DB에는 잘 삭제가 되는데 폴더에는 그대로 있음
[EnvServiceImpl]
remove() 삭제 로직 개선:
- DB 삭제 전에 첨부/본문 이미지 파일을 파일 시스템에서도 삭제하도록 추가
- imgName → 첨부 이미지, imgUrl → 본문 이미지로 분기하여 경로 생성
- FileService.deleteFile(fullPath) 통해 로컬 폴더에서도 삭제되도록 처리