### PR TITLE
[20250805] 환경톡톡 이미지 수정 완료

### DIFF
--- a/ecovery/src/main/java/com/ecovery/dto/EnvFormDto.java
+++ b/ecovery/src/main/java/com/ecovery/dto/EnvFormDto.java
@@ -9,8 +9,8 @@ import java.util.List;
 
 /**
  * 환경톡톡 게시글 등록/수정용 Form DTO
- * - 게시글 정보(EnvDto)와 이미지 ID 목록을 함께 전달받기 위한 용도
- * - REST API에서 @RequestPart로 multipart/form-data를 처리할 때 사용됨
+ * - 게시글 정보(EnvDto), 첨부 이미지 파일, 삭제할 이미지 ID 및 본문 이미지 정보 등을 함께 전달
+ * - 등록 및 수정 공통 폼 역할 수행
  *
  * @author : yukyeong
  * @fileName : EnvFormDto
@@ -31,20 +31,22 @@ import java.util.List;
 public class EnvFormDto {
 
     @Valid
-    private EnvDto envDto; // 게시글 본문 정보
+    private EnvDto envDto; // 게시글 본문 정보 (제목, 내용, 카테고리 등 포함)
 
-    private List<Long> deleteImgIds = new ArrayList<>(); // 이미지 수정. 삭제용 ID 리스트
+    // 첨부 이미지 수정 시 삭제 대상 이미지 ID 리스트
+    private List<Long> deleteImgIds = new ArrayList<>();
 
-    private List<MultipartFile> envImgFiles = new ArrayList<>(); // 이미지 파일들 추가
+    // 새로 추가될 첨부 이미지 파일 리스트
+    private List<MultipartFile> envImgFiles = new ArrayList<>();
 
     public EnvFormDto(EnvDto envDto) {
         this.envDto = envDto;
         this.envImgFiles = new ArrayList<>(); // null 방지 초기화
     }
 
-    // 프론트에서 본문에 삽입된 이미지의 src만 따서 배열로 전송하는 용도
+    // 본문에 삽입된 이미지(src) 목록 - DB 저장 또는 중복 등록 방지를 위해 사용
     private List<String> contentImgUrls = new ArrayList<>();
 
-    // 삭제용
+    // 수정 시 본문에서 제거된 이미지(src) 목록 - 파일 시스템 및 DB에서 삭제 처리에 사용
     private List<String> deleteContentImgUrls = new ArrayList<>();
 }

--- a/ecovery/src/main/java/com/ecovery/dto/EnvImgDto.java
+++ b/ecovery/src/main/java/com/ecovery/dto/EnvImgDto.java
@@ -6,8 +6,9 @@ import java.time.LocalDateTime;
 
 /**
  * 환경톡톡 이미지 DTO
- * 클라이언트 <-> 서비스 계층 간 데이터 전송용 객체
- * API 응답 또는 뷰 렌더링용으로 사용됨
+ * - env_img 테이블의 레코드를 표현하는 객체
+ * - 클라이언트 <-> 서비스 계층 간 이미지 정보 전송에 사용
+ * - 뷰 렌더링, 이미지 목록 조회, 등록 응답 등에 활용됨
  *
  * @author : yukyeong
  * @fileName : EnvImgDto

--- a/ecovery/src/main/java/com/ecovery/mapper/EnvImgMapper.java
+++ b/ecovery/src/main/java/com/ecovery/mapper/EnvImgMapper.java
@@ -2,6 +2,7 @@ package com.ecovery.mapper;
 
 import com.ecovery.domain.EnvImgVO;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
@@ -16,6 +17,7 @@ import java.util.List;
  * @history
  *     - 250726 | yukyeong | 이미지 등록, 조회, 삭제 메서드 정의
        - 250801 | yukyeong | 이미지 URL 기반 삭제 메서드 deleteByImgUrl(String imgUrl) 추가
+       - 250805 | yukyeong | 게시글 ID + 이미지 URL 중복 여부 검사용 existsByImgUrlAndEnvId 메서드 추가 (본문 이미지 중복 insert 방지)
  */
 
 @Mapper
@@ -38,5 +40,9 @@ public interface EnvImgMapper {
 
     // 이미지 URL 삭제
     public int deleteByImgUrl(String imgUrl);
+
+    // 게시글 ID + 이미지 URL 중복 여부 검사용 (본문 이미지 중복 insert 방지)
+    public boolean existsByImgUrlAndEnvId(@Param("imgUrl") String imgUrl,
+                                          @Param("envId") Long envId);
 
 }

--- a/ecovery/src/main/java/com/ecovery/service/EnvImgService.java
+++ b/ecovery/src/main/java/com/ecovery/service/EnvImgService.java
@@ -17,6 +17,7 @@ import java.util.List;
       - 250726 | yukyeong | 이미지 등록, 조회, 삭제 서비스 메서드 정의 (EnvImgDto 기반)
       - 250801 | yukyeong | 이미지 URL만 등록하는 register(EnvImgDto) 메서드 추가
                             이미지 URL 기반 삭제 메서드 deleteByImgUrl(String imgUrl) 추가
+      - 250805 | yukyeong | 본문 이미지 중복 등록 방지를 위한 existsByImgUrlAndEnvId 메서드 추가
  */
 
 public interface EnvImgService {
@@ -38,4 +39,7 @@ public interface EnvImgService {
 
     // 이미지 URL 삭제
     public int deleteByImgUrl(String imgUrl);
+
+    // 본문 이미지 중복 등록 방지
+    public boolean existsByImgUrlAndEnvId(String imgUrl, Long envId);
 }

--- a/ecovery/src/main/java/com/ecovery/service/EnvImgServiceImpl.java
+++ b/ecovery/src/main/java/com/ecovery/service/EnvImgServiceImpl.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
       - 250731 | yukyeong | 브라우저 접근용 URL 경로 수정: /images → /ecovery 로 변경
       - 250801 | yukyeong | 이미지 파일 없이 URL만 등록하는 register(EnvImgDto) 구현
                             이미지 URL 기반 삭제 기능 deleteByImgUrl(String imgUrl) 구현
+      - 250805 | yukyeong | 본문 이미지 중복 등록 방지를 위한 existsByImgUrlAndEnvId 구현
  */
 
 @Service
@@ -208,6 +209,12 @@ public class EnvImgServiceImpl implements EnvImgService{
     private String extractFileName(String imgUrl) {
         if (imgUrl == null || !imgUrl.contains("/")) return null;
         return imgUrl.substring(imgUrl.lastIndexOf("/") + 1);
+    }
+
+    // 본문 이미지 중복 등록 방지를 위한 existsByImgUrlAndEnvId 구현
+    @Override
+    public boolean existsByImgUrlAndEnvId(String imgUrl, Long envId) {
+        return envImgMapper.existsByImgUrlAndEnvId(imgUrl, envId);
     }
 
 }

--- a/ecovery/src/main/java/com/ecovery/service/EnvService.java
+++ b/ecovery/src/main/java/com/ecovery/service/EnvService.java
@@ -43,4 +43,6 @@ public interface EnvService {
 
     // 이미지 URL 삭제
     public int deleteContentImg(String imgUrl);
+
+
 }

--- a/ecovery/src/main/java/com/ecovery/service/EnvServiceImpl.java
+++ b/ecovery/src/main/java/com/ecovery/service/EnvServiceImpl.java
@@ -5,6 +5,7 @@ import com.ecovery.dto.Criteria;
 import com.ecovery.dto.EnvDto;
 import com.ecovery.dto.EnvFormDto;
 import com.ecovery.dto.EnvImgDto;
+import com.ecovery.mapper.EnvImgMapper;
 import com.ecovery.mapper.EnvMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +39,7 @@ import java.util.stream.Collectors;
                            - DB 삭제 전에 첨부/본문 이미지 파일을 파일 시스템에서도 삭제하도록 추가
                            - imgName → 첨부 이미지, imgUrl → 본문 이미지로 분기하여 경로 생성
                            - FileService.deleteFile(fullPath) 통해 로컬 폴더에서도 삭제되도록 처리
+     - 250805 | yukyeong | 본문 이미지 등록 시 중복 이미지 필터링 로직 추가 (envImgService.existsByImgUrlAndEnvId)
  */
 
 @Service
@@ -183,6 +185,13 @@ public class EnvServiceImpl implements EnvService {
             for (String imgUrl : contentImgUrls) {
                 if (imgUrl != null && !imgUrl.isBlank()) {
                     imgUrl = imgUrl.trim(); // 공백 제거
+
+                    // 중복 등록 방지
+                    boolean exists = envImgService.existsByImgUrlAndEnvId(imgUrl, env.getEnvId());
+                    if (exists) {
+                        log.info("이미 등록된 본문 이미지이므로 건너뜀: {}", imgUrl);
+                        continue;
+                    }
 
                     EnvImgDto imgDto = EnvImgDto.builder()
                             .envId(env.getEnvId())

--- a/ecovery/src/main/resources/mapper/EnvImgMapper.xml
+++ b/ecovery/src/main/resources/mapper/EnvImgMapper.xml
@@ -12,6 +12,7 @@
     @history
      - 250726 | yukyeong | 이미지 등록/조회/삭제 쿼리 작성
      - 250801 | yukyeong | 이미지 URL 기반 삭제 쿼리 deleteByImgUrl 추가
+     - 250805 | yukyeong | 본문 이미지 중복 등록 방지를 위한 existsByImgUrlAndEnvId 쿼리 추가
 -->
 
 <mapper namespace="com.ecovery.mapper.EnvImgMapper">
@@ -102,5 +103,20 @@
         DELETE FROM env_img
         WHERE img_url = #{imgUrl}
     </delete>
+
+    <!--
+        이미지 중복 여부 확인 쿼리
+        · 대상 테이블 : env_img
+        · 조건 : env_id + img_url 조합
+        · 반환 : 해당 이미지가 해당 게시글에 존재하는지 여부 (boolean)
+        · 용도 : 본문 이미지 등록 시 중복 insert 방지
+        · 사용처 : EnvImgServiceImpl.registerContentImgs() 등
+    -->
+    <select id="existsByImgUrlAndEnvId" resultType="boolean">
+        SELECT COUNT(*) > 0
+        FROM env_img
+        WHERE env_id = #{envId}
+          AND img_url = #{imgUrl}
+    </select>
 
 </mapper>

--- a/ecovery/src/main/resources/mapper/PaymentMapper.xml
+++ b/ecovery/src/main/resources/mapper/PaymentMapper.xml
@@ -20,7 +20,7 @@
         <result property="orderId" column="order_id" />
         <result property="orderUuid" column="order_uuid" />
         <result property="memberId" column="member_id" />
-        <result property="paymentKey" column="paymentKey" />
+        <result property="paymentKey" column="payment_key" />
         <result property="payMethod" column="pay_method" />
         <result property="payAmount" column="pay_amount" />
         <result property="payStatus" column="pay_status" />
@@ -29,7 +29,7 @@
 
     <!-- 결제내역 저장 -->
     <insert id="insertPayment" parameterType="com.ecovery.domain.PaymentVO" useGeneratedKeys="true" keyProperty="paymentId">
-        insert into payment (order_id, order_uuid, member_id, paymentKey, pay_method, pay_amount, pay_status, paid_at)
+        insert into payment (order_id, order_uuid, member_id, payment_key, pay_method, pay_amount, pay_status, paid_at)
         values (#{orderId}, #{orderUuid}, #{memberId}, #{paymentKey}, #{payMethod}, #{payAmount}, #{payStatus}, NOW())
     </insert>
 </mapper>

--- a/ecovery/src/main/resources/static/js/env-modify.js
+++ b/ecovery/src/main/resources/static/js/env-modify.js
@@ -16,6 +16,7 @@
  *  - 250801 | yukyeong | 본문 이미지 수정 시 삭제된 이미지 URL 추출 및 서버 전송(deleteContentImgUrls)
  *                       - 기존 vs 수정 후 이미지 목록 비교하여 삭제 대상 식별
  *                       - contentImgUrls와 함께 envFormDto로 전송하여 DB 반영 처리
+ *  - 250805 | yukyeong | 삭제된 본문 이미지 식별 시 공백/대소문자 차이로 인해 삭제되지 않는 문제 해결 (normalize 함수 추가)
  */
 
 
@@ -125,8 +126,14 @@ async function submitModifiedPost() {
     const prevImgUrls = extractImageUrlsFromHtml(window.initialContent || "");
     const newImgUrls = extractImageUrlsFromHtml(content);
 
+    // ✅ (2) 공백, 대소문자 차이 방지를 위한 정규화 함수
+    const normalize = (url) => url?.trim().toLowerCase();
+
+
     // ✅ (2) 삭제된 이미지 URL 식별
-    deleteContentImgUrls = prevImgUrls.filter(url => !newImgUrls.includes(url));
+    const deleteContentImgUrls = prevImgUrls
+        .map(normalize)
+        .filter(url => !newImgUrls.map(normalize).includes(url));
 
     console.log("삭제될 본문 이미지 목록:", deleteContentImgUrls);
 


### PR DESCRIPTION
1. 결제처리 오류 해결
[PaymentServiceImpl]
getPortOneAccessToken()에서
1. ObjectMapper 사용 → JSON 명시적 변환 처리
2. HttpEntity<Map> → HttpEntity<String>로 변경
3. Map<String, String> → JSON 문자열로 변환
confirmPayment()에서 (orderId == null) 로 수정
[PaymentMapper.xml] paymentKey → payment_key 로 수정

2. 환경톡톡 게시판에서 이미지 3장 중에서 1장만 삭제했을 때 삭제한 사진이 DB에 반영이 되지 않는 오류
[env-modify.js] 
삭제된 본문 이미지 식별 시 공백/대소문자 차이로 인해 삭제되지 않는 문제 해결 (normalize 함수 추가)

3. 이제 3장 중에 이미지 하나만 삭제하면 폴더에서도 삭제되고, 본문에서도 삭제됨. 
그런데 DB에는 삭제한 이미지가 하나 더 늘어나는 오류 발생
- 해결 방안 : 기존에 등록된 img_url이 현재 본문에 이미 N개 있는지 세지 말고, 그냥 한 번만 막기
→ 현재 등록하려는 URL이 이 게시글에 이미 있는지만 판단해서
있으면 → insert 하지 않음 (중복 방지) / 없으면 → insert 함

[EnvImgMapper.java]
게시글 ID + 이미지 URL 중복 여부 검사용 existsByImgUrlAndEnvId 메서드 추가 (본문 이미지 중복 insert 방지)
[EnvImgMapper.xml] 본문 이미지 중복 등록 방지를 위한 existsByImgUrlAndEnvId 쿼리 추가
[EnvImgService] 본문 이미지 중복 등록 방지를 위한 existsByImgUrlAndEnvId 메서드 추가
[EnvImgServiceImpl] 본문 이미지 중복 등록 방지를 위한 existsByImgUrlAndEnvId 구현
[EnvServiceImpl] 본문 이미지 등록 시 중복 이미지 필터링 로직 추가 (envImgService.existsByImgUrlAndEnvId)





