### PR TITLE
[20250806] 환경톡톡, 공지사항 목록 오류 수정

### DIFF
--- a/ecovery/src/main/resources/static/js/env-get.js
+++ b/ecovery/src/main/resources/static/js/env-get.js
@@ -14,6 +14,8 @@
                            - 글 삭제 버튼 이벤트 바인딩 기능 추가
                            - 본문 내용에 포함된 이미지 자동 렌더링 처리
      - 250731 | yukyeong | 수정일이 있을 경우 '작성일:' → '수정일:'로 표시 및 날짜 변경 처리
+     - 250806 | yukyeong | 목록 이동 시 검색어·카테고리·페이지 상태 유지 처리
+                           - backToListBtn 클릭 시 URL 파라미터 기반 이동
  */
 
 
@@ -27,6 +29,20 @@ const categoryMap = {
 document.addEventListener("DOMContentLoaded", function () {
     const urlParams = new URLSearchParams(window.location.search);
     const envId = urlParams.get("envId");
+
+    // ✅ 목록으로 돌아가기 버튼 처리
+    const backBtn = document.getElementById("backToListBtn");
+    if (backBtn) {
+        const pageNum = urlParams.get("pageNum") || 1;
+        const keyword = urlParams.get("keyword") || '';
+        const type = urlParams.get("type") || '';
+        const category = urlParams.get("category") || '';
+
+        const backUrl = `/env/list?pageNum=${pageNum}&keyword=${encodeURIComponent(keyword)}&type=${type}&category=${category}`;
+        backBtn.addEventListener("click", function () {
+            window.location.href = backUrl;
+        });
+    }
 
     if (!envId) {
         alert("잘못된 접근입니다.");

--- a/ecovery/src/main/resources/static/js/env-list.js
+++ b/ecovery/src/main/resources/static/js/env-list.js
@@ -9,6 +9,8 @@
  * @history
  *    - 250722 | yukyeong | 게시글 목록 비동기 로딩, 검색, 페이징 기능 구현
  *    - 250731 | yukyeong | 수정일이 존재할 경우 목록에도 수정일 우선 표시되도록 개선
+ *    - 250806 | yukyeong | 목록 초기화 시 쿼리스트링(pageNum, keyword, category) 기반 렌더링 처리
+ *                        | 상세 페이지에서 목록 복귀 시 검색어·카테고리·페이지 유지
  */
 
 // HTML 문서의 모든 요소가 완전히 로딩된 후에 실행할 코드
@@ -27,7 +29,25 @@ document.addEventListener("DOMContentLoaded", function () { // 웹 페이지의 
         });
     });
 
-    loadEnvList(); // 페이지 처음 열렸을 때, 검색 조건 없이 전체 게시글 목록을 가져옴
+    // ✅ 여기 추가: URL 파라미터 기반 초기화
+    const urlParams = new URLSearchParams(window.location.search);
+    const pageNum = parseInt(urlParams.get("pageNum")) || 1;
+    const keyword = urlParams.get("keyword") || "";
+    const category = urlParams.get("category") || "";
+
+    // 검색창에 값 설정
+    document.getElementById("searchInput").value = keyword;
+
+    // 카테고리 탭 선택 반영
+    if (category) {
+        const selectedTab = document.querySelector(`.category-tab[data-category="${category}"]`);
+        if (selectedTab) {
+            document.querySelectorAll(".category-tab").forEach(t => t.classList.remove("active"));
+            selectedTab.classList.add("active");
+        }
+    }
+    // ✅ pageNum 기반으로 목록 불러오기
+    loadEnvList(pageNum); // 페이지 처음 열렸을 때, 검색 조건 없이 전체 게시글 목록을 가져옴
 }) // DOMContentLoaded의 끝 — HTML 로딩 후 실행되는 초기화 작업 완료
 
 
@@ -94,7 +114,17 @@ function viewPost(envId) { // 사용자가 게시글 목록에서 글을 클릭�
     const keyword = document.getElementById("searchInput").value.trim(); // 검색창에 입력된 검색어를 가져옴
     const pageNum = document.querySelector(".page-btn.active")?.textContent || 1; // 현재 페이지 번호를 가져옴
 
+    // ✅ 현재 선택된 카테고리 가져오기 (이게 빠졌음!)
+    const selectedCategoryBtn = document.querySelector(".category-tab.active");
+    const category = selectedCategoryBtn?.dataset.category || "";
+
     let url = `/env/get?envId=${envId}&pageNum=${pageNum}`; // 상세 페이지의 URL을 만듦
+
+    // ✅ 카테고리 파라미터 추가
+    if (category && category !== "all") {
+        url += `&category=${category}`;
+    }
+
     if (keyword) { // 검색어가 입력되어 있다면
         url += `&type=TCW&keyword=${encodeURIComponent(keyword)}`; // URL에 검색 조건을 추가
     }

--- a/ecovery/src/main/resources/static/js/notice-get.js
+++ b/ecovery/src/main/resources/static/js/notice-get.js
@@ -18,6 +18,8 @@
                             - roleMap 추가로 관리자/사용자 역할 표시
                             - avatar 기본 이모지 설정
                             - notice-role, notice-avatar 요소에 값 바인딩 추가
+     - 250806 | yukyeong | 목록 이동 시 검색어·카테고리·페이지 상태 유지 처리
+                            - backToListBtn 클릭 시 URL 파라미터 기반 이동
 
  */
 
@@ -33,6 +35,20 @@ const categoryMap = {
 document.addEventListener("DOMContentLoaded", function () {
     const urlParams = new URLSearchParams(window.location.search);
     const noticeId = urlParams.get("noticeId");
+
+    // ✅ 목록으로 돌아가기 버튼 처리
+    const backBtn = document.getElementById("backToListBtn");
+    if (backBtn) {
+        const pageNum = urlParams.get("pageNum") || 1;
+        const keyword = urlParams.get("keyword") || '';
+        const type = urlParams.get("type") || '';
+        const category = urlParams.get("category") || '';
+
+        const backUrl = `/notice/list?pageNum=${pageNum}&keyword=${encodeURIComponent(keyword)}&type=${type}&category=${category}`;
+        backBtn.addEventListener("click", function () {
+            window.location.href = backUrl;
+        });
+    }
 
     if (!noticeId) {
         alert("잘못된 접근입니다.");

--- a/ecovery/src/main/resources/static/js/notice-list.js
+++ b/ecovery/src/main/resources/static/js/notice-list.js
@@ -11,6 +11,8 @@
  *     - 250731 | yukyeong | 수정일 우선 표시 로직 적용 (updatedAt 우선 표시)
  *     - 250731 | yukyeong | 카테고리 탭 필터링 기능 추가 (dataset.category 기반)
  *     - 250731 | yukyeong | HTML 클래스명 변경 (post-* → notice-*), CSS 스타일 연동 완료
+ *     - 250806 | yukyeong | 목록 초기화 시 쿼리스트링(pageNum, keyword, category) 기반 렌더링 처리
+ *                         | 상세 페이지에서 목록 복귀 시 검색어·카테고리·페이지 유지
  */
 
 // HTML 문서의 모든 요소가 완전히 로딩된 후에 실행할 코드
@@ -29,7 +31,26 @@ document.addEventListener("DOMContentLoaded", function () { // 웹 페이지의 
         });
     });
 
-    loadNoticeList(); // 페이지 처음 열렸을 때, 검색 조건 없이 전체 게시글 목록을 가져옴
+    // ✅ 쿼리 파라미터 기반 초기값 설정
+    const urlParams = new URLSearchParams(window.location.search);
+    const pageNum = parseInt(urlParams.get("pageNum")) || 1;
+    const keyword = urlParams.get("keyword") || "";
+    const category = urlParams.get("category") || "";
+
+    // 검색어 입력창 초기화
+    document.getElementById("searchInput").value = keyword;
+
+    // 카테고리 탭 초기화
+    if (category) {
+        const selectedTab = document.querySelector(`.category-tab[data-category="${category}"]`);
+        if (selectedTab) {
+            document.querySelectorAll(".category-tab").forEach(t => t.classList.remove("active"));
+            selectedTab.classList.add("active");
+        }
+    }
+
+    // 페이지 번호 기반으로 목록 불러오기
+    loadNoticeList(pageNum);
 }) // DOMContentLoaded의 끝 — HTML 로딩 후 실행되는 초기화 작업 완료
 
 
@@ -96,7 +117,17 @@ function viewPost(noticeId) { // 사용자가 게시글 목록에서 글을 클�
     const keyword = document.getElementById("searchInput").value.trim(); // 검색창에 입력된 검색어를 가져옴
     const pageNum = document.querySelector(".page-btn.active")?.textContent || 1; // 현재 페이지 번호를 가져옴
 
+    // ✅ 현재 선택된 카테고리 가져오기 (이게 빠졌음!)
+    const selectedCategoryBtn = document.querySelector(".category-tab.active");
+    const category = selectedCategoryBtn?.dataset.category || "";
+
     let url = `/notice/get?noticeId=${noticeId}&pageNum=${pageNum}`; // 상세 페이지의 URL을 만듦
+
+    // ✅ 카테고리 파라미터 추가
+    if (category && category !== "all") {
+        url += `&category=${category}`;
+    }
+
     if (keyword) { // 검색어가 입력되어 있다면
         url += `&type=TCW&keyword=${encodeURIComponent(keyword)}`; // URL에 검색 조건을 추가
     }

--- a/ecovery/src/main/resources/templates/env/get.html
+++ b/ecovery/src/main/resources/templates/env/get.html
@@ -11,6 +11,7 @@ GreenCycle 환경톡톡 게시글 상세보기
     - 250730 | yukyeong | 상세페이지 전체 구조 전면 수정 (레이아웃 개선, 관리자 버튼 정비 등)
     - 250731 | yukyeong | Toast UI Editor 기반 본문 표시로 전환, 첨부파일 관련 마크업 및 액션 버튼 주석 처리
     - 250802 | yukyeong | 헤더와 페이지 헤더 간 간격 축소, 불필요한 <main> 태그 제거
+    - 250806 | yukyeong | "목록으로 돌아가기" 버튼 클릭 시 쿼리스트링(pageNum, keyword, category) 반영되도록 개선
 
 -->
 
@@ -71,7 +72,7 @@ GreenCycle 환경톡톡 게시글 상세보기
                 <!-- 게시글 상세 메인 콘텐츠 -->
                 <div class="post-detail-main fade-in">
                     <!-- 뒤로가기 버튼 -->
-                    <button class="back-btn" onclick="history.back()">
+                    <button class="back-btn" id="backToListBtn">
                         ← 목록으로 돌아가기
                     </button>
 

--- a/ecovery/src/main/resources/templates/notice/get.html
+++ b/ecovery/src/main/resources/templates/notice/get.html
@@ -16,6 +16,7 @@ GreenCycle 환경톡톡 게시글 상세보기
                           - 공지사항 조회 전용 notice-get.js 연동
     - 250802 | yukyeong | 작성자 정보(author-info) 영역 구조 개선 : 아바타, 작성자명, 권한(role) 요소 분리 및 ID 지정
     - 250802 | yukyeong | 관리자 전용 영역 제목(admin-actions-title) 블록 추가
+    - 250806 | yukyeong | "목록으로 돌아가기" 버튼 클릭 시 쿼리스트링(pageNum, keyword, category) 반영되도록 개선
 -->
 
 <!DOCTYPE html>
@@ -61,7 +62,7 @@ GreenCycle 환경톡톡 게시글 상세보기
             <!-- 공지사항 상세 메인 콘텐츠 -->
             <div class="notice-detail-main fade-in">
                 <!-- 뒤로가기 버튼 -->
-                <button class="back-btn" onclick="history.back()">
+                <button class="back-btn" id="backToListBtn">
                     ← 목록으로 돌아가기
                 </button>
 


### PR DESCRIPTION
1. 상세보기 화면에서 목록화면으로 넘어가면 5페이지에서 1페이지로 돌아가는 오류 (환경톡톡)
해결방안 : 
쿼리 파라미터를 직접 사용하여 "목록으로" URL을 구성하고,
history.back() 대신 window.location.href = /env/list?... 방식으로 이동


/env
[get.html]
"목록으로 돌아가기" 버튼 클릭 시 쿼리스트링(pageNum, keyword, category) 반영되도록 개선
[env-list.js]
목록 초기화 시 쿼리스트링(pageNum, keyword, category) 기반 렌더링 처리
상세 페이지에서 목록 복귀 시 검색어·카테고리·페이지 유지
[env-get.js]
목록 이동 시 검색어·카테고리·페이지 상태 유지 처리
- backToListBtn 클릭 시 URL 파라미터 기반 이동

/notice
[get.html]
"목록으로 돌아가기" 버튼 클릭 시 쿼리스트링(pageNum, keyword, category) 반영되도록 개선
[notice-list.js]
목록 초기화 시 쿼리스트링(pageNum, keyword, category) 기반 렌더링 처리
상세 페이지에서 목록 복귀 시 검색어·카테고리·페이지 유지
[notice-get.js]
목록 이동 시 검색어·카테고리·페이지 상태 유지 처리
- backToListBtn 클릭 시 URL 파라미터 기반 이동