### PR TITLE
[20250811] 환경톡톡 수정페이지 이미지 5장 제한

### DIFF
--- a/ecovery/src/main/resources/static/js/env-register.js
+++ b/ecovery/src/main/resources/static/js/env-register.js
@@ -1,5 +1,5 @@
 /**
- * GreenCycle 환경톡톡 게시글 등록 스크립트
+ * 환경톡톡 게시글 등록 스크립트
  * 게시글 등록 페이지에서 카테고리 로딩, 유효성 검사, 이미지 삽입, 미리보기 등
  * 다양한 작성 인터랙션 기능을 제공함
  *
@@ -21,6 +21,10 @@
  *   - 250801 | yukyeong | 본문 이미지 src 추출 기능 추가(getImageSrcListFromEditor)
  *                        - submitPost() 수정: contentImgUrls 필드로 본문 이미지 리스트 포함 전송
  *                        - 이미지 등록 시 DB 저장 누락되는 오류 수정 반영
+ *   - 250811 | yukyeong | 본문 이미지 개수 제한 기능 추가
+ *                         - MAX_CONTENT_IMAGES 상수 도입 (기본 5장)
+ *                         - getImageSrcListFromEditor()로 추출 후 Set을 이용해 중복 제거
+ *                         - submitPost()에서 개수 초과 시 등록 중단 처리
  */
 
 document.addEventListener("DOMContentLoaded", function () {

--- a/ecovery/src/main/resources/templates/env/modify.html
+++ b/ecovery/src/main/resources/templates/env/modify.html
@@ -15,6 +15,8 @@ GreenCycle 환경톡톡 게시글 수정 페이지
                           - env-modify.js 및 전역 설정 변수 연동 처리
     - 250802 | yukyeong | 헤더와 페이지 헤더 간 간격 축소, 불필요한 <main> 태그 제거
     - 250802 | yukyeong | 본문 글자 수 제한 2000자 → 5000자로 확장
+    - 250811 | yukyeong | Sidebar 주석처리
+    - 250811 | yukyeong | 본문 이미지 업로드 시 최대 5장 제한 및 중복 제거 로직 적용
 -->
 
 <!DOCTYPE html>
@@ -196,6 +198,9 @@ GreenCycle 환경톡톡 게시글 수정 페이지
 
     <!-- 타임리프 변수 및 에디터 설정 -->
     <script th:inline="javascript">
+
+        const MAX_CONTENT_IMAGES = 5;
+
         const envId = /*[[${env.envId}]]*/ 0;
         const envCategory = /*[[${env.category}]]*/ null;
         const initialContent = /*[[${env.content}]]*/ "";
@@ -248,6 +253,16 @@ GreenCycle 환경톡톡 게시글 수정 페이지
             hooks: {
                 addImageBlobHook: async (blob, callback) => {
                     try {
+
+                        // 현재 본문 내 <img> 개수 계산
+                        const html = editor.getHTML();
+                        const currentCount = (html.match(/<img\s/gi) || []).length;
+
+                        if (currentCount >= MAX_CONTENT_IMAGES) {
+                            alert(`본문 이미지는 최대 ${MAX_CONTENT_IMAGES}장까지 가능합니다.`);
+                            return; // 업로드 중단
+                        }
+
                         const formData = new FormData();
                         formData.append('file', blob);
 
@@ -255,6 +270,10 @@ GreenCycle 환경톡톡 게시글 수정 페이지
                             method: 'POST',
                             body: formData
                         });
+
+                        if (!res.ok) {
+                            throw new Error('이미지 업로드 실패');
+                        }
 
                         const result = await res.json();
                         const imageUrl = `/ecovery/env/${result.fileName}`;

--- a/ecovery/src/main/resources/templates/env/register.html
+++ b/ecovery/src/main/resources/templates/env/register.html
@@ -20,6 +20,10 @@
                           - 기존 파일 첨부 영역 UI는 주석 처리됨
     - 250802 | yukyeong | 헤더와 페이지 헤더 간 간격 축소, 불필요한 <main> 태그 제거
     - 250802 | yukyeong | 본문 글자 수 제한 2000자 → 5000자로 확장
+    - 250811 | yukyeong | 본문 이미지 업로드 개수 제한 기능 추가:
+                          - MAX_CONTENT_IMAGES 상수 도입(기본 5장)
+                          - addImageBlobHook에서 현재 본문 이미지 개수 확인 후 초과 시 업로드 차단
+
 -->
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"


### PR DESCRIPTION
[env/modify.html] 
Sidebar 주석처리
본문 이미지 업로드 시 최대 5장 제한 및 중복 제거 로직 적용

[env-modify.js]
본문 이미지 중복 제거 후 최대 5장 제한 기능 추가
- 등록 페이지와 동일하게 submit 시 중복 제거 및 개수 제한 검증
- MAX_CONTENT_IMAGES 초과 시 수정 중단